### PR TITLE
Changed Dunjudge problem links to codebreaker.xyz

### DIFF
--- a/src/dynamic_programming/divide-and-conquer-dp.md
+++ b/src/dynamic_programming/divide-and-conquer-dp.md
@@ -94,7 +94,7 @@ both!
 - [CodeForces - The Bakery](https://codeforces.com/problemset/problem/834/D)
 - [CodeForces - Yet Another Minimization Problem](https://codeforces.com/contest/868/problem/F)
 - [Codechef - CHEFAOR](https://www.codechef.com/problems/CHEFAOR)
-- [Dunjudge - GUARDS](https://dunjudge.me/analysis/problems/894/) (This is the exact problem in this article.)
+- [Codebreaker - GUARDS](https://codebreaker.xyz/problem/guards) (This is the exact problem in this article.)
 - [Hackerrank - Guardians of the Lunatics](https://www.hackerrank.com/contests/ioi-2014-practice-contest-2/challenges/guardians-lunatics-ioi14)
 - [Hackerrank - Mining](https://www.hackerrank.com/contests/world-codesprint-5/challenges/mining)
 - [Kattis - Money (ACM ICPC World Finals 2017)](https://open.kattis.com/problems/money)

--- a/src/geometry/convex_hull_trick.md
+++ b/src/geometry/convex_hull_trick.md
@@ -145,11 +145,11 @@ ftype get(int x, int v = 1, int l = 0, int r = maxn) {
 
 ## Problems
 
-* [Dunjudge - TROUBLES](https://dunjudge.me/analysis/problems/896/) (simple application of Convex Hull Trick after a couple of observations)
+* [Codebreaker - TROUBLES](https://codebreaker.xyz/problem/troubles) (simple application of Convex Hull Trick after a couple of observations)
 * [CS Academy - Squared Ends](https://csacademy.com/contest/archive/task/squared-ends)
 * [Codeforces - Escape Through Leaf](http://codeforces.com/contest/932/problem/F)
 * [CodeChef - Polynomials](https://www.codechef.com/NOV17/problems/POLY)
 * [Codeforces - Kalila and Dimna in the Logging Industry](https://codeforces.com/problemset/problem/319/C)
 * [Codeforces - Product Sum](https://codeforces.com/problemset/problem/631/E)
 * [Codeforces - Bear and Bowling 4](https://codeforces.com/problemset/problem/660/F)
-* [APIO 2010 - Commando](https://dunjudge.me/analysis/problems/264/)
+* [APIO 2010 - Commando](https://codebreaker.xyz/problem/commando)


### PR DESCRIPTION
[Dunjudge](https://dunjudge.me/) is down indefinitely now so the Dunjudge problems links have been changed to [Codebreaker](https://codebreaker.xyz/problems) which has almost all of the Dunjduge problems.