### PR TITLE
Inconsistent inequality in segment_tree.md

### DIFF
--- a/src/data_structures/segment_tree.md
+++ b/src/data_structures/segment_tree.md
@@ -842,7 +842,7 @@ void update(int v, int tl, int tr, int l, int r, int addend) {
 int query(int v, int tl, int tr, int l, int r) {
     if (l > r)
         return -INF;
-    if (l <= tl && tr <= r)
+    if (l == tl && tr == r)
         return t[v];
     push(v);
     int tm = (tl + tr) / 2;


### PR DESCRIPTION
The condition `l < tl` and `tr < r` will never be true in `query()`. So only `==` can be checked.