### PR TITLE
Fix wrong variable names in connected components

### DIFF
--- a/src/graph/search-for-connected-components.md
+++ b/src/graph/search-for-connected-components.md
@@ -36,9 +36,9 @@ void dfs(int v) {
 void find_comps() {
     fill(used.begin(), used.end(), 0);
     for (int v = 0; v < n; ++v) {
-        if (!used[i]) {
+        if (!used[v]) {
             comp.clear();
-            dfs(i);
+            dfs(v);
             cout << "Component:" ;
             for (int u : comp)
                 cout << ' ' << u;


### PR DESCRIPTION
Variable in the loop in the code for search connected components is supposed to be v, not i