### PR TITLE
Rename "implicit" to "dynamic" segment tree

### DIFF
--- a/src/data_structures/segment_tree.md
+++ b/src/data_structures/segment_tree.md
@@ -1126,11 +1126,14 @@ It is easy to generate lookup tables (e.g. using $\text{map}$), that convert a v
 
 
 
-### Implicit segment tree
+### Dynamic segment tree
+
+(Called so because its shape is dynamic and the nodes are usually dynamically allocated.
+Also known as _implicit segment tree_ or _sparse segment tree_.)
 
 Previously, we considered cases when we have the ability to build the original segment tree. But what to do if the original size is filled with some default element, but its size does not allow you to completely build up to it in advance?
- 
-We can solve this problem by not explicitly creating a segment tree. Initially, we will create only the root, and we will create the other vertexes only when we need them. 
+
+We can solve this problem by creating a segment tree lazily (incrementally). Initially, we will create only the root, and we will create the other vertexes only when we need them.
 In this case, we will use the implementation on pointers(before going to the vertex children, check whether they are created, and if not, create them).
 Each query has still only the complexity $O(\log n)$, which is small enough for most use-cases (e.g. $\log_2 10^9 \approx 30$).
 

--- a/src/sequences/longest_increasing_subsequence.md
+++ b/src/sequences/longest_increasing_subsequence.md
@@ -283,7 +283,7 @@ For instance we can use a [Segment tree](../data_structures/segment_tree.md) or 
 
 This method has obviously some **shortcomings**:
 in terms of length and complexity of the implementation this approach will be worse than the method using binary search.
-In addition if the input numbers $a[i]$ are especially large, then we would have to use some tricks, like compressing the numbers (i.e. renumber them from $0$ to $n-1$), or use an implicit Segment tree (only generate the branches of the tree that are important).
+In addition if the input numbers $a[i]$ are especially large, then we would have to use some tricks, like compressing the numbers (i.e. renumber them from $0$ to $n-1$), or use a dynamic segment tree (only generate the branches of the tree that are important).
 Otherwise the memory consumption will be too high.
 
 On the other hand this method has also some **advantages**:


### PR DESCRIPTION
This might be controversial, but personally I don't really like the name "implicit" and the use might stem from competitive programming tunnel vision. In fact, the usual array-backed segment trees are [implicit](https://en.wikipedia.org/wiki/Implicit_data_structure) as they use a [specific layout](https://en.algorithmica.org/hpc/data-structures/segment-trees/#implicit-segment-trees) rather than pointers to navigate the tree. It also seems the name "dynamic" [is more popular already](https://codeforces.com/blog/entry/99074).