### PR TITLE
added congruence symbol to linear_congruence_equation

### DIFF
--- a/src/algebra/linear_congruence_equation.md
+++ b/src/algebra/linear_congruence_equation.md
@@ -39,7 +39,7 @@ It is clear that this $x^\prime$ will also be a solution of the original equatio
 However it will **not be the only solution**.
 It can be shown that the original equation has exactly $g$ solutions, and they will look like this:
 
-$$x_i = (x^\prime + i\cdot n^\prime) \pmod n \quad \text{for } i = 0 \ldots g-1$$
+$$x_i \equiv (x^\prime + i\cdot n^\prime) \pmod n \quad \text{for } i = 0 \ldots g-1$$
 
 Summarizing, we can say that the **number of solutions** of the linear congruence equation is equal to either $g = \gcd(a, n)$ or to zero.
 

--- a/src/algebra/linear_congruence_equation.md
+++ b/src/algebra/linear_congruence_equation.md
@@ -16,7 +16,7 @@ It is required to find the value $x$ from the interval $[0, n-1]$ (clearly, on t
 
 ## Solution by finding the inverse element
 
-Let us first consider a simpler case where $a$ and $n$ are **coprime** ($\gcd(a, n) \equiv 1$).
+Let us first consider a simpler case where $a$ and $n$ are **coprime** ($\gcd(a, n) = 1$).
 Then one can find the [inverse](module-inverse.md) of $a$, and multiplying both sides of the equation with the inverse, and we can get a **unique** solution.
 
 $$x \equiv b \cdot a ^ {- 1} \pmod n$$
@@ -24,7 +24,7 @@ $$x \equiv b \cdot a ^ {- 1} \pmod n$$
 Now consider the case where $a$ and $n$ are **not coprime** ($\gcd(a, n) \ne 1$).
 Then the solution will not always exist (for example $2 \cdot x \equiv 1 \pmod 4$ has no solution).
 
-Let $g \equiv \gcd(a, n)$, i.e. the [greatest common divisor](euclid-algorithm.md) of $a$ and $n$ (which in this case is greater than one).
+Let $g = \gcd(a, n)$, i.e. the [greatest common divisor](euclid-algorithm.md) of $a$ and $n$ (which in this case is greater than one).
 
 Then, if $b$ is not divisible by $g$, there is no solution. In fact, for any $x$ the left side of the equation $a \cdot x \pmod n$ , is always divisible by $g$, while the right-hand side is not divisible by it, hence it follows that there are no solutions.
 
@@ -39,15 +39,15 @@ It is clear that this $x^\prime$ will also be a solution of the original equatio
 However it will **not be the only solution**.
 It can be shown that the original equation has exactly $g$ solutions, and they will look like this:
 
-$$x_i = (x^\prime + i\cdot n^\prime) \pmod n \quad \text{for } i \equiv 0 \ldots g-1$$
+$$x_i = (x^\prime + i\cdot n^\prime) \pmod n \quad \text{for } i = 0 \ldots g-1$$
 
-Summarizing, we can say that the **number of solutions** of the linear congruence equation is equal to either $g \equiv \gcd(a, n)$ or to zero.
+Summarizing, we can say that the **number of solutions** of the linear congruence equation is equal to either $g = \gcd(a, n)$ or to zero.
 
 ## Solution with the Extended Euclidean Algorithm
 
 We can rewrite the linear congruence to the following Diophantine equation:
 
-$$a \cdot x + n \cdot k \equiv b,$$
+$$a \cdot x + n \cdot k = b,$$
 
 where $x$ and $k$ are unknown integers.
 

--- a/src/algebra/linear_congruence_equation.md
+++ b/src/algebra/linear_congruence_equation.md
@@ -16,15 +16,15 @@ It is required to find the value $x$ from the interval $[0, n-1]$ (clearly, on t
 
 ## Solution by finding the inverse element
 
-Let us first consider a simpler case where $a$ and $n$ are **coprime** ($\gcd(a, n) = 1$).
+Let us first consider a simpler case where $a$ and $n$ are **coprime** ($\gcd(a, n) \equiv 1$).
 Then one can find the [inverse](module-inverse.md) of $a$, and multiplying both sides of the equation with the inverse, and we can get a **unique** solution.
 
-$$x = b \cdot a ^ {- 1} \pmod n$$
+$$x \equiv b \cdot a ^ {- 1} \pmod n$$
 
 Now consider the case where $a$ and $n$ are **not coprime** ($\gcd(a, n) \ne 1$).
-Then the solution will not always exist (for example $2 \cdot x = 1 \pmod 4$ has no solution).
+Then the solution will not always exist (for example $2 \cdot x \equiv 1 \pmod 4$ has no solution).
 
-Let $g = \gcd(a, n)$, i.e. the [greatest common divisor](euclid-algorithm.md) of $a$ and $n$ (which in this case is greater than one).
+Let $g \equiv \gcd(a, n)$, i.e. the [greatest common divisor](euclid-algorithm.md) of $a$ and $n$ (which in this case is greater than one).
 
 Then, if $b$ is not divisible by $g$, there is no solution. In fact, for any $x$ the left side of the equation $a \cdot x \pmod n$ , is always divisible by $g$, while the right-hand side is not divisible by it, hence it follows that there are no solutions.
 
@@ -39,15 +39,15 @@ It is clear that this $x^\prime$ will also be a solution of the original equatio
 However it will **not be the only solution**.
 It can be shown that the original equation has exactly $g$ solutions, and they will look like this:
 
-$$x_i = (x^\prime + i\cdot n^\prime) \pmod n \quad \text{for } i = 0 \ldots g-1$$
+$$x_i = (x^\prime + i\cdot n^\prime) \pmod n \quad \text{for } i \equiv 0 \ldots g-1$$
 
-Summarizing, we can say that the **number of solutions** of the linear congruence equation is equal to either $g = \gcd(a, n)$ or to zero.
+Summarizing, we can say that the **number of solutions** of the linear congruence equation is equal to either $g \equiv \gcd(a, n)$ or to zero.
 
 ## Solution with the Extended Euclidean Algorithm
 
 We can rewrite the linear congruence to the following Diophantine equation:
 
-$$a \cdot x + n \cdot k = b,$$
+$$a \cdot x + n \cdot k \equiv b,$$
 
 where $x$ and $k$ are unknown integers.
 

--- a/src/algebra/linear_congruence_equation.md
+++ b/src/algebra/linear_congruence_equation.md
@@ -8,7 +8,7 @@ e_maxx_link: diofant_1_equation
 
 This equation is of the form:
 
-$$a \cdot x = b \pmod n,$$
+$$a \cdot x \equiv b \pmod n,$$
 
 where $a$, $b$ and $n$ are given integers and $x$ is an unknown integer.
 
@@ -30,7 +30,7 @@ Then, if $b$ is not divisible by $g$, there is no solution. In fact, for any $x$
 
 If $g$ divides $b$, then by dividing both sides of the equation by $g$ (i.e. dividing $a$, $b$ and $n$ by $g$), we receive a new equation:
 
-$$a^\prime \cdot x = b^\prime \pmod{n^\prime}$$
+$$a^\prime \cdot x \equiv b^\prime \pmod{n^\prime}$$
 
 in which $a^\prime$ and $n^\prime$ are already relatively prime, and we have already learned how to handle such an equation.
 We get $x^\prime$ as solution for $x$.


### PR DESCRIPTION
This change resolves issue #1069 by changing the equal sign to congruence.
Signed-off-by: Sundaram krishnan <krishnsundaram@gmail.com>