### PR TITLE
Change "number of ... bit" to  "index of ... bit"

### DIFF
--- a/src/game_theory/sprague-grundy-nim.md
+++ b/src/game_theory/sprague-grundy-nim.md
@@ -85,7 +85,7 @@ If $s \neq 0$, we have to prove that there is a move leading to a state with $t 
 
 *   Let $s \neq 0$.
     Consider the binary representation of the number $s$.
-    Let $d$ be the number of its leading (biggest value) non-zero bit.
+    Let $d$ be the index of its leading (biggest value) non-zero bit.
     Our move will be on a pile whose size's bit number $d$ is set (it must exist, otherwise the bit wouldn't be set in $s$).
     We will reduce its size $x$ to $y = x \oplus s$.
     All bits at positions greater than $d$ in $x$ and $y$ match and bit $d$ is set in $x$ but not set in $y$.


### PR DESCRIPTION
Changed "number of its leading (biggest value) non-zero bit" to "index of its leading (biggest value) non-zero bit" as latter is clearer in its intention. I believe I am not the only one who got confused by whether "number of a bit" is referring to $2^(d-1)$ (i.e. the actual value of the bit) or $d$