### PR TITLE
Integers less than 2 (especially 1) are not prime.

### DIFF
--- a/src/algebra/primality_tests.md
+++ b/src/algebra/primality_tests.md
@@ -20,12 +20,11 @@ If it is a divisor, than $n$ is definitely not prime, otherwise it is.
 
 ```cpp
 bool isPrime(int x) {
-    if (x<2) return false;
     for (int d = 2; d * d <= x; d++) {
         if (x % d == 0)
             return false;
     }
-    return true;
+    return x >= 2;
 }
 ```
 

--- a/src/algebra/primality_tests.md
+++ b/src/algebra/primality_tests.md
@@ -20,6 +20,7 @@ If it is a divisor, than $n$ is definitely not prime, otherwise it is.
 
 ```cpp
 bool isPrime(int x) {
+    if (x<2) return false;
     for (int d = 2; d * d <= x; d++) {
         if (x % d == 0)
             return false;


### PR DESCRIPTION
Integers less than 2 are not prime. I got a wrong answer because I copied this on a contest once. This corrects the error.