### PR TITLE
Update fenwick.md

### DIFF
--- a/src/data_structures/fenwick.md
+++ b/src/data_structures/fenwick.md
@@ -325,7 +325,7 @@ struct FenwickTreeOneBasedIndexing {
     }
 
     void add(int idx, int delta) {
-        for (++idx; idx < n; idx += idx & -idx)
+        for (++idx; idx <= n; idx += idx & -idx)
             bit[idx] += delta;
     }
 };


### PR DESCRIPTION
Corrected the loop condition for `FenwickTreeOneBasedIndexing` class `add` function. The previous for loop condition was `idx < n` which is now corrected to `idx <= n`.