### PR TITLE
Fixed `build` badge on the home page

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Contributors](https://img.shields.io/github/contributors/cp-algorithms/cp-algorithms.svg)](https://github.com/cp-algorithms/cp-algorithms/graphs/contributors)
 [![Pull Requests](https://img.shields.io/github/issues-pr/cp-algorithms/cp-algorithms.svg)](https://github.com/cp-algorithms/cp-algorithms/pulls)
 [![Closed Pull Requests](https://img.shields.io/github/issues-pr-closed/cp-algorithms/cp-algorithms.svg)](https://github.com/cp-algorithms/cp-algorithms/pulls?q=is%3Apr+is%3Aclosed)
-[![Build](https://github.com/cp-algorithms/cp-algorithms/workflows/test/badge.svg)](https://github.com/cp-algorithms/cp-algorithms/actions?query=branch%3Amaster+workflow%3Atest)
+[![Build](https://img.shields.io/github/actions/workflow/status/cp-algorithms/cp-algorithms/test.yml)](https://github.com/cp-algorithms/cp-algorithms/actions?query=branch%3Amaster+workflow%3Atest)
 [![Translation Progress](https://img.shields.io/badge/translation_progress-85.2%25-yellowgreen.svg)](https://github.com/cp-algorithms/cp-algorithms/wiki/Translation-Progress)
 
 The goal of this project is to translate the wonderful resource


### PR DESCRIPTION
- Used the GitHub Workflow Status badge from shields.io
- Documentation can be found here - https://shields.io/badges/git-hub-workflow-status-with-event

![image](https://github.com/cp-algorithms/cp-algorithms/assets/45748739/a5bba0df-559f-4123-925d-e2ac302e1378)
