### PR TITLE
Add "build" function to segment_tree.md

### DIFF
--- a/src/data_structures/segment_tree.md
+++ b/src/data_structures/segment_tree.md
@@ -805,6 +805,17 @@ Before traversing to a child vertex, we call $\text{push}$ and propagate the val
 We have to do this in both the $\text{update}$ function and the $\text{query}$ function.
 
 ```cpp
+void build(int a[], int v, int tl, int tr) {
+    if (tl == tr) {
+        t[v] = a[tl];
+    } else {
+        int tm = (tl + tr) / 2;
+        build(a, v*2, tl, tm);
+        build(a, v*2+1, tm+1, tr);
+        t[v] = max(t[v*2], t[v*2 + 1]);
+    }
+}
+
 void push(int v) {
     t[v*2] += lazy[v];
     lazy[v*2] += lazy[v];


### PR DESCRIPTION
Ensure that each node stores the maximum of its children. Otherwise the results of any query will be wrong, unless this node has been visited by an "update" query previously.