### PR TITLE
Safely interpolate the page title into the "report issue" button

### DIFF
--- a/src/overrides/partials/content.html
+++ b/src/overrides/partials/content.html
@@ -3,7 +3,7 @@ window.onload = function() {
 	const newIssueURL = "https://github.com/cp-algorithms/cp-algorithms/issues/new";
   const issueTitle = "Problem on article " + {{page.title | tojson }};
 	const issueBody = `
- **Article:** [{{page.title}}](${window.location.href})
+ **Article:** [`+ {{page.title | tojson }} + `](${window.location.href})
 
 **Problem:**
 <!--

--- a/src/overrides/partials/content.html
+++ b/src/overrides/partials/content.html
@@ -1,7 +1,7 @@
 <script type="text/javascript">
 window.onload = function() {
 	const newIssueURL = "https://github.com/cp-algorithms/cp-algorithms/issues/new";
-  const issueTitle = `Problem on article "{{page.title}}"`;
+  const issueTitle = "Problem on article " + {{page.title | tojson }};
 	const issueBody = `
  **Article:** [{{page.title}}](${window.location.href})
 


### PR DESCRIPTION
* Currently it is possible that the interpolation escapes the confines of the quotes

* Also in a future version of MkDocs, values will become escaped by default, so this value will become incorrect under the current approach

---

As a specific example, currently the interpolation is:

```js
`Problem on article "Integration by Simpson's formula"`
```

(easy to hack it by inserting a character such as <code>`</code> or <code>$</code>)

In a future version of MkDocs this will become wrong:

```js
`Problem on article "Integration by Simpson&#39;s formula"`
```

I am changing it to:

```js
"Problem on article " + "Integration by Simpson\u0027s formula"
```