### PR TITLE
Handle the degenerate case of convex hull consists of two identical points

### DIFF
--- a/src/geometry/convex-hull.md
+++ b/src/geometry/convex-hull.md
@@ -86,6 +86,9 @@ void convex_hull(vector<pt>& a, bool include_collinear = false) {
         st.push_back(a[i]);
     }
 
+    if (include_collinear == false && st.size() == 2 && st[0] == st[1])
+        st.pop_back();
+
     a = st;
 }
 ```


### PR DESCRIPTION
This PR addresses the situation where the convex hull consists of two identical points and the hull is strictly convex (i.e., collinear points are not included).