### PR TITLE
feat: Added an existing feature of `mkdocs-material` that allows users to copy the `code-blocks/snippets` directly.

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -25,6 +25,7 @@ theme:
     - navigation.tabs
     - toc.integrate
     - search.suggest
+    - content.code.copy
 repo_url: https://github.com/cp-algorithms/cp-algorithms
 repo_name: cp-algorithms/cp-algorithms
 edit_uri: edit/master/src/


### PR DESCRIPTION
The mkdocs-material theme has the [`content.code.copy`](https://squidfunk.github.io/mkdocs-material/reference/code-blocks/?h=cod#code-copy-button) feature from the version `9.0.0`. This will help in copying the code-blocks more easily. As there are many places where **code-blocks/code-snippets** are present I think this would be quite useful.

I added the feature to [mkdocs.yml](https://github.com/cp-algorithms/cp-algorithms/blob/master/mkdocs.yml) and tested it locally using `mkdocs serve`. I am pasting the screenshots here to show the difference.

**Before**

![image](https://github.com/cp-algorithms/cp-algorithms/assets/87087741/58905b0f-e9d8-4837-b2d0-9864d3eb50a4)


**After adding the `content.code.copy` feature** (We can see the copy button at the top-right corner of the code-block)

![image](https://github.com/cp-algorithms/cp-algorithms/assets/87087741/37d5f8ed-bb3e-499d-8854-481570200b81)


Closes #1253 