### PR TITLE
Improve title consistency in fenwick.md

### DIFF
--- a/src/data_structures/fenwick.md
+++ b/src/data_structures/fenwick.md
@@ -380,7 +380,7 @@ int point_query(int idx) {
 
 Note: of course it is also possible to increase a single point $A[i]$ with `range_add(i, i, val)`.
 
-### 3. Range Updates and Range Queries
+### 3. Range Update and Range Query
 
 To support both range updates and range queries we will use two BITs namely $B_1[]$ and $B_2[]$, initialized with zeros.
 


### PR DESCRIPTION
The range operations are mentioned earlier on in the markdown file as follows:
> Point Update and Range Query
> Range Update and Point Query
> Range Update and Range Query

All the actual section/subsection titles stay consistent with this list except for the third one (which is instead "Range Updates and Range Queries").