### PR TITLE
Update bridge-searching-online.md

### DIFF
--- a/src/graph/bridge-searching-online.md
+++ b/src/graph/bridge-searching-online.md
@@ -174,7 +174,6 @@ int find_cc(int v) {
 }
  
 void make_root(int v) {
-    v = find_2ecc(v);
     int root = v;
     int child = -1;
     while (v != -1) {


### PR DESCRIPTION
`a = find_2ecc(a)` is called in the `add_edge` function, then again in the `make_root(int v)` function as the first line which is redundant.