### PR TITLE
Update Cutpoints implementation.md

### DIFF
--- a/src/graph/cutpoints.md
+++ b/src/graph/cutpoints.md
@@ -58,11 +58,14 @@ void dfs(int v, int p = -1) {
             low[v] = min(low[v], tin[to]);
         } else {
             dfs(to, v);
-            low[v] = min(low[v], low[to]);
-            if (low[to] >= tin[v] && p!=-1)
-                IS_CUTPOINT(v);
             ++children;
         }
+    }
+    for (int to : adj[v]) {
+        if (to != p)
+            low[v] = min(low[v], low[to]);
+        if (low[to] >= tin[v] && p!=-1)
+                IS_CUTPOINT(v);
     }
     if(p == -1 && children > 1)
         IS_CUTPOINT(v);


### PR DESCRIPTION
The given implementation will give a wrong answer for a case when a node v has more than one child, some of which(having lower indexes) have back edges while others(having higher indexes) do not have back edges as the low[v] value of node will become less than it's tin[v] value and the condition for being cut point will not be satisfied for later(higher index) children. In this updated implementation, the low value of node v is updated, and the condition for being a cut point is checked in a separate loop after all the children have been visited. An example for which the given implementation would give a wrong answer is an undirected connected graph having 8 vertices and 10 edges between the following vertices -  1) 0, 1
2) 1, 2
3) 2, 3
4) 3, 4
5) 4, 5
6) 1, 5
7) 5, 3
8) 2, 6
9) 6, 7
10) 7, 2