### PR TITLE
Update and fix disjoint_set_union.md

### DIFF
--- a/src/data_structures/disjoint_set_union.md
+++ b/src/data_structures/disjoint_set_union.md
@@ -345,12 +345,14 @@ pair<int, int> find_set(int v) {
 }
 
 void union_sets(int a, int b) {
+    int dist_a = find_set(a).second;
+    int dist_b = find_set(b).second;
     a = find_set(a).first;
     b = find_set(b).first;
     if (a != b) {
         if (rank[a] < rank[b])
             swap(a, b);
-        parent[b] = make_pair(a, 1);
+        parent[b] = make_pair(a, dist_a + dist_b + 1);
         if (rank[a] == rank[b])
             rank[a]++;
     }


### PR DESCRIPTION
There was a mistake in the code that calculates the distance between a node and its representative, where there was an error in calculating the distance when merging two sets. I fixed it after testing, experimenting, and consulting with experts. Explanation:
If the representative node for a is different from the representative node for b, then both a and b belong to different sets. This means that there is no common path between the two paths:
- The first path from a to p[a] = find_set(a)
- The second path from b to p[b] = find_set(b)

Therefore, the distance from p[b] to p[a] is equal to: dist(p[b], p[a]) = dist(p[a], a) + dist(p[b], b) + 1

Where +1 represents the length of the edge between a and b.

For example, let's consider having 4 nodes 1,2,3,4 with an edge between 1 and 2, and an edge between 3 and 4.
p[1].first=1    p[1].second=0
p[2].first=1    p[2].second=1
p[3].first=4    p[3].second=1
p[4].first=4    p[4].second=0

When we add an edge between 2 and 3, the following will happen: union_sets(2,3)
a = set_find(2).first = 1
b = set_find(3).first = 4

We want to make 1 the representative node for 4. Therefore, the distance between 1 and 4 is the sum of the distances from 1 to 2, then from 2 to 3, then from 3 to 4, which equals 3.

According to the incorrect old code, it would consider the distance between 1 and 4 as 1, which is incorrect.

I hope the explanation is clear. I have tested the old and new code, and I am confident that it will solve this issue while demonstrating the solution mentioned above. I hope the modification will be approved for the benefit of everyone, and thank you for this opportunity and for your efforts.