### PR TITLE
Change to cloudflare CDN for polyfill io

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -32,7 +32,7 @@ edit_uri: edit/master/src/
 copyright: Text is available under the <a href="https://github.com/cp-algorithms/cp-algorithms/blob/master/LICENSE">Creative Commons Attribution Share Alike 4.0 International</a> License<br/>Copyright &copy; 2014 - 2024 by <a href="https://github.com/cp-algorithms/cp-algorithms/graphs/contributors">cp-algorithms contributors</a>
 extra_javascript:
   - javascript/config.js
-  - https://polyfill.io/v3/polyfill.min.js?features=es6
+  - https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?features=es6
   - https://unpkg.com/mathjax@3/es5/tex-mml-chtml.js
 extra_css:
   - stylesheets/extra.css


### PR DESCRIPTION
As of recently, the service polyfill io is no longer trustworthy as it has [been used to inject malicious code into websites](https://blog.cloudflare.com/automatically-replacing-polyfill-io-links-with-cloudflares-mirror-for-a-safer-internet). To address the security concern the CDN was modified to the cloudflare mirror.