### PR TITLE
Fix typo in a comment: "occurence" -> "occurrence"

### DIFF
--- a/test/test_divide_and_conquer_dp.cpp
+++ b/test/test_divide_and_conquer_dp.cpp
@@ -26,7 +26,7 @@ int brute_force() {
     return dp_before[n - 1];
 }
 
-// sum of last occurrence of x - first occurence of x for all unique x in the range
+// sum of last occurrence of x - first occurrence of x for all unique x in the range
 long long C(int i, int j) {
     map<int, int> last;
 


### PR DESCRIPTION
Fixed the typo "occurence" -> "occurrence", in a comment.