### PR TITLE
Add a practice problem for the Grundy theorem

### DIFF
--- a/src/game_theory/sprague-grundy-nim.md
+++ b/src/game_theory/sprague-grundy-nim.md
@@ -209,3 +209,4 @@ In fact, $g(n)$ has a period of length 34 starting with $n=52$.
 - [HackerRank - Tower Breakers, Revisited!](https://www.hackerrank.com/contests/5-days-of-game-theory/challenges/tower-breakers-2)
 - [HackerRank - Tower Breakers, Again!](https://www.hackerrank.com/contests/5-days-of-game-theory/challenges/tower-breakers-3/problem)
 - [HackerRank - Chessboard Game, Again!](https://www.hackerrank.com/contests/5-days-of-game-theory/challenges/a-chessboard-game)
+- [Atcoder - ABC368F - Dividing Game](https://atcoder.jp/contests/abc368/tasks/abc368_f)


### PR DESCRIPTION
They mention in [the editorial](https://atcoder.jp/contests/abc368/editorial/10829) that problem [ABC368 - F - Dividing Game](https://atcoder.jp/contests/abc368/tasks/abc368_f) is related to the Grundy theorem. So I add it into the practice problem section.