### PR TITLE
Removes redundant check from dinic's dfs

### DIFF
--- a/src/graph/dinic.md
+++ b/src/graph/dinic.md
@@ -118,8 +118,6 @@ struct Dinic {
     }
 
     long long dfs(int v, long long pushed) {
-        if (pushed == 0)
-            return 0;
         if (v == t)
             return pushed;
         for (int& cid = ptr[v]; cid < (int)adj[v].size(); cid++) {

--- a/src/graph/dinic.md
+++ b/src/graph/dinic.md
@@ -106,7 +106,7 @@ struct Dinic {
             int v = q.front();
             q.pop();
             for (int id : adj[v]) {
-                if (edges[id].cap - edges[id].flow < 1)
+                if (edges[id].cap == edges[id].flow)
                     continue;
                 if (level[edges[id].u] != -1)
                     continue;

--- a/src/graph/dinic.md
+++ b/src/graph/dinic.md
@@ -154,3 +154,7 @@ struct Dinic {
     }
 };
 ```
+
+## Practice Problems
+
+* [SPOJ: FASTFLOW](https://www.spoj.com/problems/FASTFLOW/)

--- a/src/graph/dinic.md
+++ b/src/graph/dinic.md
@@ -118,6 +118,8 @@ struct Dinic {
     }
 
     long long dfs(int v, long long pushed) {
+        if (pushed == 0)
+            return 0;
         if (v == t)
             return pushed;
         for (int& cid = ptr[v]; cid < (int)adj[v].size(); cid++) {

--- a/src/graph/dinic.md
+++ b/src/graph/dinic.md
@@ -125,7 +125,7 @@ struct Dinic {
         for (int& cid = ptr[v]; cid < (int)adj[v].size(); cid++) {
             int id = adj[v][cid];
             int u = edges[id].u;
-            if (level[v] + 1 != level[u] || edges[id].cap - edges[id].flow < 1)
+            if (level[v] + 1 != level[u])
                 continue;
             long long tr = dfs(u, min(pushed, edges[id].cap - edges[id].flow));
             if (tr == 0)


### PR DESCRIPTION
These two lines check a condition that is already checked in the for loop and can safely be removed. The test.sh file was also executed 

Referenced issue: 
Redundant check in dfs of dinic #1344 