### PR TITLE
Fix beecrowd problems hyperlinks

### DIFF
--- a/src/geometry/convex-hull.md
+++ b/src/geometry/convex-hull.md
@@ -194,6 +194,6 @@ void convex_hull(vector<pt>& a, bool include_collinear = false) {
 
 * [Kattis - Convex Hull](https://open.kattis.com/problems/convexhull)
 * [Kattis - Keep the Parade Safe](https://open.kattis.com/problems/parade)
-* [URI 1464 - Onion Layers](https://www.urionlinejudge.com.br/judge/en/problems/view/1464)
+* [Latin American Regionals 2006 - Onion Layers](https://matcomgrader.com/problem/9413/onion-layers/)
 * [Timus 1185: Wall](http://acm.timus.ru/problem.aspx?space=1&num=1185)
 * [Usaco 2014 January Contest, Gold - Cow Curling](http://usaco.org/index.php?page=viewproblem2&cpid=382)

--- a/src/num_methods/simpson-integration.md
+++ b/src/num_methods/simpson-integration.md
@@ -64,4 +64,4 @@ double simpson_integration(double a, double b){
 
 ## Practice Problems
 
-* [URI - Environment Protection](https://www.urionlinejudge.com.br/judge/en/problems/view/1297)
+* [Latin American Regionals 2012 - Environment Protection](https://matcomgrader.com/problem/9335/environment-protection/)


### PR DESCRIPTION
In the articles, there are two links to problems from URI Online Judge, which has changed to [beecrowd](https://judge.beecrowd.com/en). Therefore, those links are now broken, because they always redirect to [this page](https://beecrowd.com/), which does not show any problem, and is not even part of the actual beecrowd online judge system.
So, this PR updates the links to those two problems.
Please notice that it is still necessary to log in to beecrowd before viewing the problem.

