### PR TITLE
Update finding-negative-cycle-in-graph.md

### DIFF
--- a/src/graph/finding-negative-cycle-in-graph.md
+++ b/src/graph/finding-negative-cycle-in-graph.md
@@ -35,15 +35,17 @@ int n, m;
 vector<Edge> edges;
 const int INF = 1000000000;
 
-void solve()
-{
-    vector<int> d(n);
+void solve() {
+    vector<int> d(n, INF);
     vector<int> p(n, -1);
     int x;
+    
+    d[0] = 0;
+
     for (int i = 0; i < n; ++i) {
         x = -1;
         for (Edge e : edges) {
-            if (d[e.a] + e.cost < d[e.b]) {
+            if (d[e.a] < INF && d[e.a] + e.cost < d[e.b]) {
                 d[e.b] = max(-INF, d[e.a] + e.cost);
                 p[e.b] = e.a;
                 x = e.b;
@@ -71,6 +73,7 @@ void solve()
         cout << endl;
     }
 }
+
 ```
 
 ## Using Floyd-Warshall algorithm


### PR DESCRIPTION
I have done the following changes -
1. **Initialization of d**:The distance vector d is initialized as infinity, except for the source node for which the value of 0 is taken at the start.
2. **Loop condition**: if(d[e.a] < INF && d[e.a] + e.cost < d[e.b]) ensures that you only relax edges from nodes that have finite distance.

Reason -
The distance array d is never initialized to **infinity (INF)**, and therefore the condition if(d[e.a] < INF) is always true. This should probably be because of the initialization with d's default values of 0, which is wrong for algorithms like the Bellman-Ford algorithm (which this appears to be), where we need to initialize all distances to infinity except for the starting node.