### PR TITLE
Removed reduntant check in Manacher's algorithm

### DIFF
--- a/src/string/manacher.md
+++ b/src/string/manacher.md
@@ -147,7 +147,7 @@ vector<int> manacher_odd(string s) {
     vector<int> p(n + 2);
     int l = 1, r = 1;
     for(int i = 1; i <= n; i++) {
-        p[i] = max(0, min(r - i, p[l + (r - i)]));
+        p[i] = min(r - i, p[l + (r - i)]);
         while(s[i - p[i]] == s[i + p[i]]) {
             p[i]++;
         }


### PR DESCRIPTION
Reduntant code removal suggested in #1372 

> p[i] = max(0, min(r - i, p[l + (r - i)]));

changed to 

> p[i] = min(r - i, p[l + (r - i)]);

as r-i will never go below zero.