### PR TITLE
fix: correct low-link value update in bridge-finding algorithm (#1329)

### DIFF
--- a/src/graph/bridge-searching.md
+++ b/src/graph/bridge-searching.md
@@ -67,7 +67,7 @@ void dfs(int v, int p = -1) {
             continue;
         }
         if (visited[to]) {
-            low[v] = min(low[v], tin[to]);
+            low[v] = min(low[v], low[to]);
         } else {
             dfs(to, v);
             low[v] = min(low[v], low[to]);


### PR DESCRIPTION
In the DFS-based bridge-finding algorithm, there was an issue where the low-link value was incorrectly updated when revisiting an already visited node. The previous logic incorrectly used the discovery time (tin) to update the low-link value, leading to incorrect results in detecting bridges.

The line:
`low[v] = min(low[v], tin[to]);`
was replaced with:
`low[v] = min(low[v], low[to]);`
to correctly reflect the low-link value of the adjacent node.

This change resolves issue #1329, ensuring proper bridge detection in the graph traversal.