### PR TITLE
Much simpler range sum operation

### DIFF
--- a/src/data_structures/segment_tree.md
+++ b/src/data_structures/segment_tree.md
@@ -193,7 +193,7 @@ In order to simplify the code, this function always does two recursive calls, ev
 ```{.cpp file=segment_tree_implementation_sum}
 int sum(int v, int tl, int tr, int l, int r) {
     if (tr < l || tl > r) return 0;  // no overlap
-    if (tl >= l && tr <= r) return t[v];  // complete overlap
+    if (l <= tl && tr <= r) return t[v];  // nested segment
 
     int tm = (tl + tr) / 2;
     // partial overlap

--- a/src/data_structures/segment_tree.md
+++ b/src/data_structures/segment_tree.md
@@ -91,8 +91,6 @@ There are three possible cases:
 
 So, processing a sum query is a function that recursively calls itself with left and right children until it finds a complete or no overlap between ranges.
 
-So processing a sum query is a function that recursively calls itself once with either the left or the right child (without changing the query boundaries), or twice, once for the left and once for the right child (by splitting the query into two subqueries). And the recursion ends, whenever the boundaries of the current query segment coincides with the boundaries of the segment of the current vertex. In that case the answer will be the precomputed value of the sum of this segment, which is stored in the tree.
-
 In other words, the calculation of the query is a traversal of the tree, which spreads through all necessary branches of the tree, and uses the precomputed sum values of the segments in the tree. 
 
 Obviously we will start the traversal from the root vertex of the Segment Tree.


### PR DESCRIPTION
I have provided the overview and implementation of a much simpler range sum query function, which does not require splitting the original query.  I have explicitly outlined the three cases that may arise while processing a range sum query and the code directly reflects these cases. This implementation is much more beginner friendly and intuitive.