### PR TITLE
Bug in the face order check

### DIFF
--- a/src/geometry/planar.md
+++ b/src/geometry/planar.md
@@ -125,20 +125,14 @@ std::vector<std::vector<size_t>> find_faces(std::vector<Point> vertices, std::ve
                 e = e1;
             }
             std::reverse(face.begin(), face.end());
-            int sign = 0;
-            for (size_t j = 0; j < face.size(); j++) {
-                size_t j1 = (j + 1) % face.size();
-                size_t j2 = (j + 2) % face.size();
-                int64_t val = vertices[face[j]].cross(vertices[face[j1]], vertices[face[j2]]);
-                if (val > 0) {
-                    sign = 1;
-                    break;
-                } else if (val < 0) {
-                    sign = -1;
-                    break;
-                }
+            Point p1 = vertices[face[0]];
+            __int128 sum = 0;
+            for (int j = 0; j < face.size(); ++j) {
+                Point p2 = vertices[face[j]];
+                Point p3 = vertices[face[(j + 1) % face.size()]];
+                sum += (p2 - p1).cross(p3 - p2);
             }
-            if (sign <= 0) {
+            if (sum <= 0) {
                 faces.insert(faces.begin(), face);
             } else {
                 faces.emplace_back(face);

--- a/test/test_planar_faces.cpp
+++ b/test/test_planar_faces.cpp
@@ -93,8 +93,34 @@ void test_cycle_with_chain() {
     assert(equal_cycles(faces[1], {2, 5, 4, 5, 2, 1, 0, 3}));
 }
 
+void test_ccw_angle() {
+    std::vector<Point> p = {
+        Point(0, 2),
+        Point(1, 3),
+        Point(0, 1),
+        Point(1, 0),
+        Point(-1, 0),
+        Point(-1, 3)
+    };
+
+    std::vector<std::vector<size_t>> adj = {
+        {1, 5},
+        {0, 2},
+        {1, 3},
+        {2, 4},
+        {3, 5},
+        {0, 4}
+    };
+
+    auto faces = find_faces(p, adj);
+    assert(faces.size() == 2u);
+    assert(equal_cycles(faces[0], {0, 1, 2, 3, 4, 5}));
+    assert(equal_cycles(faces[1], {5, 4, 3, 2, 1, 0}));
+}
+
 int main() {
     test_simple();
     test_degenerate();
     test_cycle_with_chain();
+    test_ccw_angle();
 }


### PR DESCRIPTION
Current check for a polygon order is incorrect, and it breaks on the following test:

![Screenshot 2024-11-15 181100](https://github.com/user-attachments/assets/04d3061c-2fdf-41ff-8ea6-829b77f22e3b)
Here's the code that generates this test:
```c++
vector<Point> pts = {{0, 2}, {1, 3}, {0, 1}, {1, 0}, {-1, 0}, {-1, 3}};
vector<vector<size_t>> adj(pts.size());
auto add_edge = [&](int u, int v) {
    adj[u].push_back(v);
    adj[v].push_back(u);
};
add_edge(0, 1);
add_edge(1, 2);
add_edge(2, 3);
add_edge(3, 4);
add_edge(4, 5);
add_edge(5, 0);
```
For an outer face (1→2→3→4→5→0), the previous version of the algorithm would first check the triplet 1→2→3. Since this triplet is ordered in counter-clockwise order, it would incorrectly mark this face as inner.

So, instead we should use something different. I used the oriented area, however, since the coordinates are stored as int64_t, I had to use __int128, which doesn't feel that elegant. 

