### PR TITLE
Update delaunay.md

### DIFF
--- a/src/geometry/delaunay.md
+++ b/src/geometry/delaunay.md
@@ -268,7 +268,7 @@ pair<QuadEdge*, QuadEdge*> build_tr(int l, int r, vector<pt>& p) {
         else
             basel = connect(basel->rev(), lcand->rev());
     }
-    return make_pair(ldo, rdo);
+    return make_pair(ldo, rdi);
 }
 
 vector<tuple<pt, pt, pt>> delaunay(vector<pt> p) {


### PR DESCRIPTION
 **Article:** [Delaunay triangulation and Voronoi diagram](https://cp-algorithms.com/geometry/delaunay.html)

**Problem:** 

There is a typo. The return value of `build_tr` should be `{ldo, rdi}`, not `{ldo, rdo}`.