### PR TITLE
simplify bridge-searching expression

### DIFF
--- a/src/graph/bridge-searching.md
+++ b/src/graph/bridge-searching.md
@@ -22,13 +22,12 @@ Pick an arbitrary vertex of the graph $root$ and run [depth first search](depth-
 
 Now we have to learn to check this fact for each vertex efficiently. We'll use "time of entry into node" computed by the depth first search.
 
-So, let $\mathtt{tin}[v]$ denote entry time for node $v$. We introduce an array $\mathtt{low}$ which will let us store the node with earliest entry time found in the DFS search that a node $v$ can reach with a single edge from itself or its descendants. $\mathtt{low}[v]$ is the minimum of $\mathtt{tin}[v]$, the entry times $\mathtt{tin}[p]$ for each node $p$ that is connected to node $v$ via a back-edge $(v, p)$ and the values of $\mathtt{low}[to]$ for each vertex $to$ which is a direct descendant of $v$ in the DFS tree:
+So, let $\mathtt{tin}[v]$ denote entry time for node $v$. We introduce an array $\mathtt{low}$ which will let us store the node with earliest entry time found in the DFS search that a node $v$ can reach with a single edge from itself or its descendants. $\mathtt{low}[v]$ is the minimum of $\mathtt{tin}[v]$, the entry times $\mathtt{low}[p]$ for each node $p$ that is connected to node $v$ via a back-edge $(v, p)$ and the values of $\mathtt{low}[to]$ for each vertex $to$ which is a direct descendant of $v$ in the DFS tree:
 
 $$\mathtt{low}[v] = \min \left\{ 
     \begin{array}{l}
     \mathtt{tin}[v] \\ 
-    \mathtt{tin}[p]  &\text{ for all }p\text{ for which }(v, p)\text{ is a back edge} \\ 
-    \mathtt{low}[to] &\text{ for all }to\text{ for which }(v, to)\text{ is a tree edge}
+    \mathtt{low}[to] &\text{ for all }to\text{ for which }(v, to)\text{ is a tree edge, whether they are descendants in the DFS tree or already visited ancestors (i.e., back-edges)}
     \end{array}
 \right\}$$
 
@@ -67,7 +66,7 @@ void dfs(int v, int p = -1) {
             continue;
         }
         if (visited[to]) {
-            low[v] = min(low[v], tin[to]);
+            low[v] = min(low[v], low[to]);
         } else {
             dfs(to, v);
             low[v] = min(low[v], low[to]);


### PR DESCRIPTION
- simplification in expression. reduced 3 different checks to 2.
current expression:
```
low[node] = min(low[node], tin[ancestor], low[to])
```
proposed expression:
```
low[node] = min(low[node], low[to])    // whether "to" is descendants or already visited ancestor (i.e. back-edge)
```

- complete explaination

We can further improve the intuition behind the `low[]` array. We know that `low[node]` stores the lowest entry time of any node that is **reachable** from `node`, including via back edges. The `tin[node]` represents the time when `node` was first discovered during DFS.

When we encounter a **back-edge** from `node` to one of its ancestors (say `ancestor`), the earlier logic suggests we consider `tin[ancestor]` to update `low[node]`. However, we can **simplify and strengthen** this by observing that if `ancestor` can reach further up in the DFS tree (through its own back-edges), we can directly use `low[ancestor]` instead.

So instead of:

```
low[node] = min(low[node], tin[ancestor])
```

We use:

```
low[node] = min(low[node], low[ancestor])
```

This works because `low[ancestor]` already reflects the **lowest reachable ancestor** for `ancestor`, and since `node` can reach `ancestor`, it can also reach everything that `ancestor` can.

This simplification helps propagate the true lowest entry time more effectively through the DFS tree and back-edges.

Thus, the final update rule becomes:

```
low[cur] = min(low[cur], low[to])
```

for all adjacent `to`, whether they are descendants in the DFS tree or already visited ancestors (i.e., back-edges).

