### PR TITLE
small modification in basic geometry dot product

### DIFF
--- a/src/geometry/basic-geometry.md
+++ b/src/geometry/basic-geometry.md
@@ -180,7 +180,7 @@ double angle(point2d a, point2d b) {
 ```
 
 To see the next important property we should take a look at the set of points $\mathbf r$ for which $\mathbf r\cdot \mathbf a = C$ for some fixed constant $C$.
-You can see that this set of points is exactly the set of points for which the projection onto $\mathbf a$ is the point $C \cdot \dfrac{\mathbf a}{|\mathbf a|}$ and they form a hyperplane orthogonal to $\mathbf a$.
+You can see that this set of points is exactly the set of points for which the projection onto $\mathbf a$ is the point $C \cdot \dfrac{\mathbf a}{|\mathbf a| ^ 2}$ and they form a hyperplane orthogonal to $\mathbf a$.
 You can see the vector $\mathbf a$ alongside with several such vectors having same dot product with it in 2D on the picture below:
 
 <div style="text-align: center;">


### PR DESCRIPTION
> To see the next important property we should take a look at the set of points $\mathbf r$ for which $\mathbf r\cdot \mathbf a = C$ for some fixed constant $C$.
You can see that this set of points is exactly the set of points for which the projection onto $\mathbf a$ is the point $C \cdot \dfrac{\mathbf a}{|\mathbf a|}$ and they form a hyperplane orthogonal to $\mathbf a$.

I guess for $\mathbf r\cdot \mathbf a = C$ the point of projection is $\mathbf r \cos \theta$ which is of magnitude $C/|\mathbf a|$ and has direction of $\hat{a}$ (unit vec along ${\mathbf a}$) so the point is $C \cdot \dfrac{ \hat{\mathbf{a}}}{|\mathbf a|}$ which evaluates to  the point $C \cdot \dfrac{\mathbf a}{|\mathbf a|^2}$