### PR TITLE
Fix grammar: add missing 'is' in website text

### DIFF
--- a/src/data_structures/stack_queue_modification.md
+++ b/src/data_structures/stack_queue_modification.md
@@ -11,7 +11,7 @@ first we will modify a stack in a way that allows us to find the smallest elemen
 
 ## Stack modification
 
-We want to modify the stack data structure in such a way, that it possible to find the smallest element in the stack in $O(1)$ time, while maintaining the same asymptotic behavior for adding and removing elements from the stack.
+We want to modify the stack data structure in such a way, that it is possible to find the smallest element in the stack in $O(1)$ time, while maintaining the same asymptotic behavior for adding and removing elements from the stack.
 Quick reminder, on a stack we only add and remove elements on one end.
 
 To do this, we will not only store the elements in the stack, but we will store them in pairs: the element itself and the minimum in the stack starting from this element and below.


### PR DESCRIPTION
Corrected a grammatical error by adding the missing verb 'is' in the website content. This ensures proper sentence structure and improves readability.