### PR TITLE
docs: fix bridge count wording to "one or more" in bridge-searching-online.md

### DIFF
--- a/src/graph/bridge-searching-online.md
+++ b/src/graph/bridge-searching-online.md
@@ -57,7 +57,7 @@ When adding the next edge $(a, b)$ there can occur three situations:
     In this case, this edge forms a cycle along with some of the old bridges.
     All these bridges end being bridges, and the resulting cycle must be compressed into a new 2-edge-connected component.
 
-    Thus, in this case the number of bridges decreases by two or more.
+    Thus, in this case the number of bridges decreases by one or more.
 
 Consequently the whole task is reduced to the effective implementation of all these operations over the forest of 2-edge-connected components.
 


### PR DESCRIPTION
The original text stated that the number of bridges decreases by “two or more,” which is incorrect in some cases. 

For example, in this graph:
1-2-3-1
3-4
4-5-6-4

There is one bridge (3–4). Adding an edge between 1 and 4 removes only that single bridge.

This change updates the text to say “one or more,” which is accurate in all cases.