### PR TITLE
Update manhattan-distance.md

### DIFF
--- a/src/geometry/manhattan-distance.md
+++ b/src/geometry/manhattan-distance.md
@@ -67,11 +67,11 @@ To prove this, we just need to analyze the signs of $m$ and $n$. And it's left a
 
 We may apply this equation to the Manhattan distance formula to find out that
 
-$$d((x_1, y_1), (x_2, y_2)) = |x_1 - x_2| + |y_1 - y_2| = \text{max}(|(x_1 + y_1) - (x_2 + y_2)|, |(x_1 - y_1) - (x_2 - y_2)|).$$
+$$d((x_1, y_1), (x_2, y_2)) = |x_1 - x_2| + |y_1 - y_2| = \text{max}(|(x_1 + y_1) - (x_2 + y_2)|, |(y_1 - x_1) - (y_2 - x_2)|).$$
 
-The last expression in the previous equation is the [Chebyshev distance](https://en.wikipedia.org/wiki/Chebyshev_distance) of the points $(x_1 + y_1, x_1 - y_1)$ and $(x_2 + y_2, x_2 - y_2)$. This means that, after applying the transformation
+The last expression in the previous equation is the [Chebyshev distance](https://en.wikipedia.org/wiki/Chebyshev_distance) of the points $(x_1 + y_1, y_1 - x_1)$ and $(x_2 + y_2, y_2 - x_2)$. This means that, after applying the transformation
 
-$$\alpha : (x, y) \to (x + y, x - y),$$
+$$\alpha : (x, y) \to (x + y, y - x),$$
 
 the Manhattan distance between the points $p$ and $q$ turns into the Chebyshev distance between $\alpha(p)$ and $\alpha(q)$.
 


### PR DESCRIPTION
Transformation \alpha was wrong, because it should just Quote: rotation of the plane followed by a dilation about a center

Wrong transformation: (x=1,y=100) -> (x'=101, y'=-99) (wrong transformation is 135 degrees clockwise in this case, not 45),
 
Correct transformation: (x=1,y=100) -> (x'=101, y'=99)

Basically, I removed reflection over line x