### PR TITLE
Add supporters page

### DIFF
--- a/src/supporters.md
+++ b/src/supporters.md
@@ -1,0 +1,23 @@
+---
+title: Supporters
+search:
+  exclude: true
+---
+# Supporters
+
+
+
+# Current Team
+[Oleksandr Kulkov](https://github.com/adamant-pwn)
+[Michael Hayter](https://github.com/mhayter)
+[Bartosz Kostka](https://github.com/Kostero)
+[Akram Rakhmetulla](https://github.com/spike1236)
+[Jakob Kogler](https://github.com/jakobkogler)
+
+
+
+# Legendary Supporters
+[Jakob Kogler](https://github.com/jakobkogler)
+[Oleksandr Kulkov](https://github.com/adamant-pwn)
+[RodionGork](https://github.com/RodionGork)
+[Mariia Mykhailova](https://github.com/tcNickolas)


### PR DESCRIPTION
I wasn't sure if we wanted a supporters page on the actual website.  Regardless I think having a "Legendary Supporters" page is appropriate for the founders and/or substantial supporters like @jakobkogler and @adamant-pwn.

This likely should be automated at some point (scrape the analysis page on github).