### PR TITLE
Clarify definition of opt(i, j): choose maximum k among optimal candidates

### DIFF
--- a/src/dynamic_programming/knuth-optimization.md
+++ b/src/dynamic_programming/knuth-optimization.md
@@ -13,7 +13,7 @@ The Speedup is applied for transitions of the form
 
 $$dp(i, j) = \min_{i \leq k < j} [ dp(i, k) + dp(k+1, j) + C(i, j) ].$$
 
-Similar to [divide and conquer DP](./divide-and-conquer-dp.md), let $opt(i, j)$ be the value of $k$ that minimizes the expression in the transition ($opt$ is referred to as the "optimal splitting point" further in this article). The optimization requires that the following holds:
+Similar to [divide and conquer DP](./divide-and-conquer-dp.md), let $opt(i, j)$ be the maximum value of $k$ that minimizes the expression in the transition ($opt$ is referred to as the "optimal splitting point" further in this article). The optimization requires that the following holds:
 
 $$opt(i, j-1) \leq opt(i, j) \leq opt(i+1, j).$$
 


### PR DESCRIPTION
# Clarify definition of `opt(i, j)` to specify maximum `k` among optimal candidates

## Description
This PR updates the documentation to clarify the definition of `opt(i, j)`:

- Previously, it was ambiguous when multiple values of `k` achieved the optimum.  
- The reference explicitly states that we should take the **maximum** value of `k` among all optimal candidates.  
- This change makes the intended behavior explicit and avoids confusion in implementations.  

## Motivation
Clarifying this definition ensures consistency with the reference and prevents misinterpretation when different values of `k` yield the same optimum.  

## Changes
- Clarified wording in `opt(i, j)` definition.  
- Specified that the chosen `k` must be the maximum among all optimal candidates.  

> The reference is https://dl.acm.org/doi/pdf/10.1145/800141.804691, specifically, when we define $K_c$ on the left column, the reference make it clear we must choose the maximum $k$.