### PR TITLE
fix: Binary Search with arbitary predicate, Invariant loop condition issue

### DIFF
--- a/src/num_methods/binary_search.md
+++ b/src/num_methods/binary_search.md
@@ -89,7 +89,7 @@ Proof of correctness supposing a transition point exists, that is $f(0)=0$ and $
 
 ```cpp
 ... // f(i) is a boolean function such that f(0) <= ... <= f(n-1)
-int l = -1, r = n;
+int l = 0, r = n-1;
 while (r - l > 1) {
     int m = (l + r) / 2;
     if (f(m)) {


### PR DESCRIPTION
1. The proof states that a transition point exists, i.e f(0)=0, f(n-1) = 1 . 
2. The proof also states that the loop maintains the invariant f(l)=0 and f(r) = 1 when r-l >1 . 
3. Strict loop invariance assumes that the condition [holds before, and after the loop.](https://www.cs.cornell.edu/courses/cs2112/2020fa/lectures/lecture.html?id=loopinv)
4. For l=-1 , f(l) is not 0, its undefined. 

We can easily bypass that setting `l=0, r = n-1` 
In this implementation we dont need edge-case work, as we have a guaranteed transition point.


Any thoughts? did i miss anything? 🤔 