### PR TITLE
Add 2 practice problems to 2sat.md (2 SAT)

### DIFF
--- a/src/graph/2SAT.md
+++ b/src/graph/2SAT.md
@@ -191,3 +191,4 @@ struct TwoSatSolver {
  * [CSES : Giant Pizza](https://cses.fi/problemset/task/1684)
  * [Codeforces: +-1](https://codeforces.com/contest/1971/problem/H)
  * [Gym: (C) Colorful Village](https://codeforces.com/gym/104772/problem/C)
+ * [POI: Renovation](https://szkopul.edu.pl/problemset/problem/xNjwUvwdHQoQTFBrmyG8vD1O/site/?key=statement)


### PR DESCRIPTION
Add link for Colorful Village problem (2 SAT)

It's from Codeforces Gym: https://codeforces.com/gym/104772/problem/C

Also, I have a question: Can we add problems from Polish Olympiad in Informatics? The online judge is available here: https://szkopul.edu.pl/ . Some problems are available in English (only problem statements; editorials are only in Polish) and I think they are nice problems

For example this problem: https://szkopul.edu.pl/problemset/problem/xNjwUvwdHQoQTFBrmyG8vD1O/site/?key=statement also uses 2-SAT