### PR TITLE
Primality tests: Add trivial code for seven-base

### DIFF
--- a/src/algebra/primality_tests.md
+++ b/src/algebra/primality_tests.md
@@ -215,6 +215,31 @@ bool MillerRabin(u64 n) { // returns true if n is prime, else returns false.
 It's also possible to do the check with only 7 bases: 2, 325, 9375, 28178, 450775, 9780504 and 1795265022.
 However, since these numbers (except 2) are not prime, you need to check additionally if the number you are checking is equal to any prime divisor of those bases: 2, 3, 5, 13, 19, 73, 193, 407521, 299210837.
 
+```cpp
+bool MillerRabin(u64 n) { // returns true if n is prime, else returns false.
+    if (n < 2)
+        return false;
+
+    int r = 0;
+    u64 d = n - 1;
+    while ((d & 1) == 0) {
+        d >>= 1;
+        r++;
+    }
+
+    for (int a : {3, 5, 13, 19, 73, 193, 407521, 299210837}) {
+        if (n == a)
+            return true;
+    }
+
+    for (int a : {2, 325, 9375, 28178, 450775, 9780504, 1795265022}) {
+        if (check_composite(n, a, d, r))
+            return false;
+    }
+    return true;
+}
+```
+
 ## Practice Problems
 
 - [SPOJ - Prime or Not](https://www.spoj.com/problems/PON/)


### PR DESCRIPTION
The seven base version uses five fewer bases than the twelve-base version. That's 5 fewer binpower calls in the positive case, a 41.7% reduction. Based on that I think including the (very trivial) code for it is worthwhile.

Well, since we're already there, perhaps adding trial division with, say, the first 25 primes would greatly speed up the average case... nope, not going down that path.

Actually we should perhaps do go down that path. That's what every practical implementation does.

* * *
Most obvious place to add TD without adding another list of primes is after the `(n == a)` test. Just return false on `(n % a == 0)`!

But then you check godbolt gcc 15.2 `-O3` and --- what? it's using `div`? What happened to division by constants being turned to some kind of mul? Turns out it only does that if you put the `(n % a == 0)` test in a separate loop from the `check_composite` test. And it never happens at `-O2` possibly due to lack of loop splitting. The more you know.