### PR TITLE
correct log n base 2 instead of 2 log n

### DIFF
--- a/src/algebra/binary-exp.md
+++ b/src/algebra/binary-exp.md
@@ -29,7 +29,7 @@ Let's write $n$ in base 2, for example:
 
 $$3^{13} = 3^{1101_2} = 3^8 \cdot 3^4 \cdot 3^1$$
 
-Since the number $n$ has exactly $\lfloor \log_2 n \rfloor + 1$ digits in base 2, we only need to perform $O(\log n)$ multiplications, if we know the powers $a^1, a^2, a^4, a^8, \dots, a^{\lfloor \log_2 n \rfloor}$.
+Since the number $n$ has exactly $\lfloor \log_2 n \rfloor + 1$ digits in base 2, we only need to perform $O(\log n)$ multiplications, if we know the powers $a^1, a^2, a^4, a^8, \dots, a^{2^{\lfloor \log_2 n \rfloor}}$.
 
 So we only need to know a fast way to compute those.
 Luckily this is very easy, since an element in the sequence is just the square of the previous element.


### PR DESCRIPTION
- Before:

<img width="941" height="73" alt="image" src="https://github.com/user-attachments/assets/16ab75ce-78c3-44cc-bc5a-b4a14eb2b251" />

- Final :

<img width="593" height="86" alt="image" src="https://github.com/user-attachments/assets/0218a64d-a9c8-4eb8-b666-02bebbbfac90" />


- Change log n base 2 instead of 2 log n, it must have been there from a typo.