### PR TITLE
Vector orientation on cross product is incorrect

### DIFF
--- a/src/geometry/basic-geometry.md
+++ b/src/geometry/basic-geometry.md
@@ -278,7 +278,7 @@ A line can be defined via its direction vector $\mathbf d$ and an initial point 
 It is defined as $(\mathbf r - \mathbf r_0)\times\mathbf d=0$ or as $(\mathbf r - \mathbf a)\times (\mathbf b - \mathbf a) = 0$.
 As for planes, it can be defined by three points $\mathbf a$, $\mathbf b$ and $\mathbf c$ as $(\mathbf r - \mathbf a)\cdot((\mathbf b - \mathbf a)\times (\mathbf c - \mathbf a))=0$ or by initial point $\mathbf r_0$ and two direction vectors lying in this plane $\mathbf d_1$ and $\mathbf d_2$: $(\mathbf r - \mathbf r_0)\cdot(\mathbf d_1\times \mathbf d_2)=0$.
 
-In 2D the pseudo-scalar product also may be used to check the orientation between two vectors because it is positive if the rotation from the first to the second vector is clockwise and negative otherwise.
+In 2D the pseudo-scalar product also may be used to check the orientation between two vectors because it is positive if the rotation from the first to the second vector is counter-clockwise and negative otherwise.
 And, of course, it can be used to calculate areas of polygons, which is described in a different article.
 A triple product can be used for the same purpose in 3D space.
 


### PR DESCRIPTION
Positive cross product should be counter-clockwise. Mentioned at issue #1592 
