### PR TITLE
Fix image in basic-geometry.md

### DIFF
--- a/src/geometry/basic-geometry.md
+++ b/src/geometry/basic-geometry.md
@@ -197,7 +197,7 @@ In the same manner a plane can be defined in 3D.
 
 Assume you have three vectors $\mathbf a$, $\mathbf b$ and $\mathbf c$ in 3D space joined in a parallelepiped as in the picture below:
 <div style="text-align: center;">
-  <img src="https://upload.wikimedia.org/wikipedia/commons/thumb/3/3e/Parallelepiped_volume.svg/240px-Parallelepiped_volume.svg.png" alt="Three vectors">
+  <img src="https://upload.wikimedia.org/wikipedia/commons/thumb/3/3e/Parallelepiped_volume.svg/250px-Parallelepiped_volume.svg.png" alt="Three vectors">
 </div>
 
 How would you calculate its volume?


### PR DESCRIPTION
The parallelepiped image in the cross product section was broken, changed the image size from 240px to 250px to match one of [the standard Wikimedia image sizes](https://w.wiki/GHai).