### PR TITLE
Add biderctional-BFS Pb

### DIFF
--- a/src/graph/breadth-first-search.md
+++ b/src/graph/breadth-first-search.md
@@ -183,3 +183,4 @@ After that we run a BFS to find the shortest walk from the starting vertex $(s, 
 * [CSES - Labyrinth](https://cses.fi/problemset/task/1193)
 * [CSES - Message Route](https://cses.fi/problemset/task/1667/)
 * [CSES - Monsters](https://cses.fi/problemset/task/1194)
+* [UVA 704 - Colour Hash](https://onlinejudge.org/index.php?option=com_onlinejudge&Itemid=8&category=9&page=show_problem&problem=645) (bidirectional BFS)


### PR DESCRIPTION
## Add UVa 704 (Colour Hash) to BFS practice problems

Adds [UVa 704 – Colour Hash](https://onlinejudge.org/index.php?option=com_onlinejudge&Itemid=8&category=9&page=show_problem&problem=645) to the Practice Problems list in the [Breadth-first search](https://cp-algorithms.com/graph/breadth-first-search.html) article.

### Why this problem

It's a really elegant showcase of **bidirectional BFS**. The puzzle is a two-ring marble shuffle with a single fixed target state, so a naive one-directional BFS blows up: the branching factor (4 rotation moves) over up to ~16 moves makes the search space huge.

Bidirectional BFS halves the effective depth instead of exploring $b^{16}$, you meet in the middle at roughly $2 \cdot b^{8}$. The trick that makes it click here:

- **Precompute the backward frontier once.** Since the target is constant across all test cases, you BFS *outward from the target* a fixed number of moves and cache every reachable state → path. This runs a single time at startup.
- **Search forward per query** from the scrambled input, and the moment a forward state lands in the cached backward map, you've found the meeting point.
- **Stitch the path.** The forward half is taken as-is; the backward half is reversed *and* each move is swapped for its inverse (CW ↔ CCW on each ring) to convert "moves that reach the target" into "moves from the meeting point to the target."

It's a clean, self-contained example of the meet-in-the-middle idea applied to BFS exactly the kind of problem that makes the technique intuitive, which is why it's a great fit for this article.
