### PR TITLE
Fix multiple typos

### DIFF
--- a/src/algebra/balanced-ternary.md
+++ b/src/algebra/balanced-ternary.md
@@ -53,7 +53,7 @@ $$ 64_{10} = 02101_{3} $$
 
 Let us process it from the least significant (rightmost) digit:
 
-- `1`,`0` and `1` are skipped as it is.( Because `0` and `1` are allowed in balanced ternary )
+- `1`, `0` and `1` are skipped as they are. (Because `0` and `1` are allowed in balanced ternary)
 - `2` is turned into `Z` increasing the digit to its left, so we get `1Z101`.
 
 The final result is `1Z101`.
@@ -68,10 +68,10 @@ $$ 237_{10} = 22210_{3} $$
 
 Let us process it from the least significant (rightmost) digit:
 
-- `0` and `1` are skipped as it is.( Because `0` and `1` are allowed in balanced ternary )
+- `0` and `1` are skipped as they are. (Because `0` and `1` are allowed in balanced ternary)
 - `2` is turned into `Z` increasing the digit to its left, so we get `23Z10`.
 - `3` is turned into `0` increasing the digit to its left, so we get `30Z10`.
-- `3` is turned into `0` increasing the digit to its left( which is by default `0` ), and so we get `100Z10`.
+- `3` is turned into `0` increasing the digit to its left (which is by default `0`), and so we get `100Z10`.
 
 The final result is `100Z10`.
 

--- a/src/algebra/divisors.md
+++ b/src/algebra/divisors.md
@@ -39,7 +39,7 @@ p_1^{e_1} & p_1^{e_1} & p_1^{e_1} \cdot p_2 & p_1^{e_1} \cdot p_2^2 & \dots & p_
 
 So the number of divisors is trivially $(e_1 + 1) \cdot (e_2 + 1)$.
 
-* A similar argument can be made if there are more then two distinct prime factors.
+* A similar argument can be made if there are more than two distinct prime factors.
 
 
 ```cpp

--- a/src/graph/breadth-first-search.md
+++ b/src/graph/breadth-first-search.md
@@ -130,7 +130,7 @@ Thus, we perform normal BFS from each of the vertices, but do not reset the arra
 * Finding a solution to a problem or a game with the least number of moves, if each state of the game can be represented by a vertex of the graph, and the transitions from one state to the other are the edges of the graph.
 
 * Finding the shortest path in a graph with weights 0 or 1:
-This requires just a little modification to normal breadth-first search: Instead of maintaining array $used[]$, we will now check if the distance to vertex is shorter than current found distance, then if the current edge is of zero weight, we add it to the front of the queue else we add it to the back of the queue.This modification is explained in more detail in the article [0-1 BFS](01_bfs.md).
+This requires just a little modification to normal breadth-first search: Instead of maintaining array $used[]$, we will now check if the distance to vertex is shorter than current found distance, then if the current edge is of zero weight, we add it to the front of the queue else we add it to the back of the queue. This modification is explained in more detail in the article [0-1 BFS](01_bfs.md).
 
 * Finding the shortest cycle in a directed unweighted graph:
 Start a breadth-first search from each vertex.


### PR DESCRIPTION
## Fix minor typos in three articles

This PR fixes a few small, unambiguous typos in the article prose. No content,
math, or code logic is changed — only punctuation, spacing, and one wrong word.

### Changes

**`src/algebra/divisors.md`**
- "more **then** two distinct prime factors" → "more **than** two" (wrong word).

**`src/graph/breadth-first-search.md`**
- "...we add it to the back of the queue.**This** modification..." → added the
  missing space after the period ("queue. This modification").

**`src/algebra/balanced-ternary.md`** (Examples 1 and 2)
- "skipped as **it is**" → "skipped as **they are**" (subject is plural).
- "skipped as they are**.( Because**...)" → "skipped as they are**. (Because**...)"
  (missing space after the period, removed stray padding inside the parentheses).
- "`1`**,**`0`" → "`1`**, **`0`" (missing space after the comma).
- "its left**( which** is by default `0` **)**" → "its left **(which** is by
  default `0`**)**" (missing space before the parenthesis, removed stray padding).

### Notes for reviewers
- Purely cosmetic/grammar fixes; rendered math and all code snippets are untouched.
- Diff is 3 files, 5 lines changed.
