### PR TITLE
Clarify edge traversal assumption in shortest path criterion

### DIFF
--- a/src/graph/breadth-first-search.md
+++ b/src/graph/breadth-first-search.md
@@ -142,7 +142,7 @@ From all such cycles (at most one from each BFS) choose the shortest.
 To do this, run two breadth first searches:
 one from $a$ and one from $b$.
 Let $d_a []$ be the array containing shortest distances obtained from the first BFS (from $a$) and $d_b []$ be the array containing shortest distances obtained from the second BFS from $b$.
-Now for every edge $(u, v)$ it is easy to check whether that edge lies on any shortest path between $a$ and $b$:
+Now for every edge $(u, v)$ it is easy to check whether that edge lies on any shortest path between $a$ and $b$, assuming that $d_a [u] < d_a [v]$ i.e. $u$ comes before $v$ when going from $a$ to $b$:
 the criterion is the condition $d_a [u] + 1 + d_b [v] = d_a [b]$.
 
 * Find all the vertices on any shortest path between a given pair of vertices $(a, b)$.


### PR DESCRIPTION
Clarify the condition for checking edges on shortest paths between vertices in BFS.

## What does this PR do?
This updates the documentation/notes on finding shortest paths using Breadth-First Search (BFS) to clarify a hidden assumption in the edge-checking formula.

## Why necessary?
The original text stated that for every edge $(u, v)$, the criterion to check if it lies on the shortest path between $a$ and $b$ is $d_a[u] + 1 + d_b[v] = d_a[b]$. However, this equation only holds true if we assume a specific orientation where the path travels from $u$ to $v$. Without explicitly stating $d_a[u] < d_a[v]$, a reader might incorrectly apply the formula in the reverse direction ($v \to u$), leading to logical errors in undirected graphs.

## Changes proposed:
Appended clarifying text to line 145 explicitly stating the assumption: assuming that $d_a[u] < d_a[v]$ i.e. $u$ comes before $v$ when going from $a$ to $b$