### PR TITLE
Add a performance trick to 0-1 BFS

### DIFF
--- a/src/graph/01_bfs.md
+++ b/src/graph/01_bfs.md
@@ -74,6 +74,27 @@ while (!q.empty()) {
     }
 }
 ```
+A further [performance improvement](https://medium.com/@ahhz_/why-you-should-stop-using-std-deque-for-0-1-bfs-60b742a96b7f?sharedUserId=ahhz_) can be achieved by using two vectors as buckets for the queue. This avoids pointer chasing and cache misses associated with deque.
+
+```cpp
+vector<int> d(n, INF);
+d[s] = 0;
+vector<int> q0, q1;
+q0.push_front(s);
+while (!(q0.empty())) {
+    int v = q0.back();
+    q0.pop_back();
+    for (auto edge : adj[v]) {
+        int u = edge.first;
+        int w = edge.second;
+        if (d[v] + w < d[u]) {
+            d[u] = d[v] + w;
+            (w == 0 ? q0 : q1).push_back(u);
+        }
+    }
+    if(q0.empty()) swap(q0, q1);
+}
+```
 
 ## Dial's algorithm
 

--- a/src/graph/01_bfs.md
+++ b/src/graph/01_bfs.md
@@ -74,7 +74,7 @@ while (!q.empty()) {
     }
 }
 ```
-A further [performance improvement](https://medium.com/@ahhz_/why-you-should-stop-using-std-deque-for-0-1-bfs-60b742a96b7f?sharedUserId=ahhz_) can be achieved by using two vectors as buckets for the queue. This avoids pointer chasing and cache misses associated with deque.
+A further [performance improvement](https://github.com/ahhz/two_tier_queue) can be achieved by using two vectors as buckets for the queue. This avoids pointer chasing and cache misses associated with deque.
 
 ```cpp
 vector<int> d(n, INF);
@@ -89,10 +89,16 @@ while (!(q0.empty())) {
         int w = edge.second;
         if (d[v] + w < d[u]) {
             d[u] = d[v] + w;
-            (w == 0 ? q0 : q1).push_back(u);
+            if(w == 0) {
+                q0.push_back(u);
+            } else {
+                q1.push_back(u);
+            }
         }
     }
-    if(q0.empty()) swap(q0, q1);
+    if(q0.empty()) {
+        swap(q0, q1);
+    }
 }
 ```
 

--- a/src/graph/01_bfs.md
+++ b/src/graph/01_bfs.md
@@ -80,7 +80,7 @@ A further [performance improvement](https://medium.com/@ahhz_/why-you-should-sto
 vector<int> d(n, INF);
 d[s] = 0;
 vector<int> q0, q1;
-q0.push_front(s);
+q0.push_back(s);
 while (!(q0.empty())) {
     int v = q0.back();
     q0.pop_back();


### PR DESCRIPTION
This proposal improves the performance of the existing 0-1 BFS solution.  By using a two-bucket solution instead of a single deque. Further details [here](https://medium.com/@ahhz_/why-you-should-stop-using-std-deque-for-0-1-bfs-47f315be7523)