### PR TITLE
Improve LIS subsequence restoration

### DIFF
--- a/src/dynamic_programming/longest_increasing_subsequence.md
+++ b/src/dynamic_programming/longest_increasing_subsequence.md
@@ -255,13 +255,40 @@ int lis(vector<int> const& a) {
 ### Restoring the subsequence
 
 It is also possible to restore the subsequence using this approach.
-This time we have to maintain two auxiliary arrays.
-One that tells us the index of the elements in $d[]$.
-And again we have to create an array of "ancestors" $p[i]$.
-$p[i]$ will be the index of the previous element for the optimal subsequence ending in element $i$.
+Traditionally, this requires maintaining two auxiliary arrays: one that tells us the index of the elements in $d[]$, and an array of "ancestors" $p[i]$ that points to the index of the previous element for the optimal subsequence ending in element $i$.
 
-It's easy to maintain these two arrays in the course of iteration over the array $a[]$ alongside the computations of $d[]$.
-And at the end it is not difficult to restore the desired subsequence using these arrays.
+However, we can restore the subsequence in a more memory-efficient way by only maintaining a single auxiliary array $p[i]$, which stores the length of the LIS ending at $a[i]$ (i.e., the index in $d[]$ where $a[i]$ was placed).
+
+Because the array $a$ is processed from left to right, if we know the length of the LIS is $L$, we can iterate backwards through the original array $a[]$. The first element we encounter moving backwards that satisfies $p[i] == L - 1$ is mathematically guaranteed to be strictly smaller than the current element in our restored sequence, making it a valid predecessor.
+
+```{.cpp file=lis_method2_nlogn_restore}
+vector<int> lis(vector<int> const& a) {
+    int n = a.size();
+    if (n == 0) return {};
+
+    vector<int> d, p(n);
+    for (int i = 0; i < n; i++) {
+        auto it = lower_bound(d.begin(), d.end(), a[i]);
+        p[i] = it - d.begin();
+        if (it == d.end())
+            d.push_back(a[i]);
+        else
+            *it = a[i];
+    }
+
+    int l = d.size();
+    vector<int> subseq;
+    l--;
+    for (int i = n - 1; i >= 0; i--) {
+        if (p[i] == l) {
+            subseq.push_back(a[i]);
+            l--;
+        }
+    }
+    reverse(subseq.begin(), subseq.end());
+    return subseq;
+}
+```
 
 ## Solution in $O(n \log n)$ with data structures {data-toc-label="Solution in O(n log n) with data structures"}
 

--- a/src/dynamic_programming/longest_increasing_subsequence.md
+++ b/src/dynamic_programming/longest_increasing_subsequence.md
@@ -257,9 +257,16 @@ int lis(vector<int> const& a) {
 It is also possible to restore the subsequence using this approach.
 Traditionally, this requires maintaining two auxiliary arrays: one that tells us the index of the elements in $d[]$, and an array of "ancestors" $p[i]$ that points to the index of the previous element for the optimal subsequence ending in element $i$.
 
-However, we can restore the subsequence in a more memory-efficient way by only maintaining a single auxiliary array $p[i]$, which stores the length of the LIS ending at $a[i]$ (i.e., the index in $d[]$ where $a[i]$ was placed).
+However, we can restore the subsequence in a more memory-efficient way, using only a single auxiliary array $p[0 \dots n-1]$.
+We let $p[i]$ be the position in $d[]$ at which $a[i]$ was placed, so that the longest increasing subsequence ending in $a[i]$ has length $p[i] + 1$.
 
-Because the array $a$ is processed from left to right, if we know the length of the LIS is $L$, we can iterate backwards through the original array $a[]$. The first element we encounter moving backwards that satisfies $p[i] == L - 1$ is mathematically guaranteed to be strictly smaller than the current element in our restored sequence, making it a valid predecessor.
+Now suppose the length of the LIS is $L$, and let us iterate over $a[]$ backwards, picking the last element with $p[i] = L - 1$, then the last element before it with $p[i] = L - 2$, and so on down to $p[i] = 0$.
+Every element picked this way is a valid predecessor of the previously picked one.
+Indeed, suppose we have already picked $a[j]$ with $p[j] = l + 1$, and let $a[i]$ be the last element before it with $p[i] = l$.
+Since $d[l]$ always holds the most recent element placed at position $l$, it was equal to $a[i]$ at the moment $a[j]$ was processed.
+And the binary search placed $a[j]$ at position $l + 1$ exactly because $d[l] < a[j]$, therefore $a[i] < a[j]$.
+
+Collecting the elements this way and reversing them at the end gives us a longest increasing subsequence.
 
 ```{.cpp file=lis_method2_nlogn_restore}
 vector<int> lis(vector<int> const& a) {
@@ -276,10 +283,9 @@ vector<int> lis(vector<int> const& a) {
             *it = a[i];
     }
 
-    int l = d.size();
+    int l = d.size() - 1;
     vector<int> subseq;
-    l--;
-    for (int i = n - 1; i >= 0; i--) {
+    for (int i = n - 1; i >= 0 && l >= 0; i--) {
         if (p[i] == l) {
             subseq.push_back(a[i]);
             l--;

--- a/test/test_lis.cpp
+++ b/test/test_lis.cpp
@@ -20,6 +20,10 @@ namespace Method2_nlogn {
 #include "lis_method2_nlogn.h"
 }
 
+namespace Method2_nlogn_Restore {
+#include "lis_method2_nlogn_restore.h"
+}
+
 int main() {
     vector<int> a = {0, 8, 4, 12, 2, 10, 6, 14, 1, 9, 5, 13, 3, 11, 7, 15};
 
@@ -31,4 +35,14 @@ int main() {
     assert(Method2::lis(a) == 6);
 
     assert(Method2_nlogn::lis(a) == 6);
+
+    vector<int> subseq2 = {0, 2, 6, 9, 11, 15};
+    assert(Method2_nlogn_Restore::lis(a) == subseq2);
+
+    vector<int> empty;
+    assert(Method2_nlogn_Restore::lis(empty).empty());
+
+    vector<int> decreasing = {5, 4, 3, 2, 1};
+    vector<int> single = {1};
+    assert(Method2_nlogn_Restore::lis(decreasing) == single);
 }


### PR DESCRIPTION
## Summary
- Add a memory-efficient way to restore an LIS from the O(n log n) approach.
- Include a C++ snippet that reconstructs one valid LIS using one auxiliary array.

## Testing
- Compiled and ran the new snippet in a one-off C++ check.
- Compiled and ran existing `test_lis.cpp`.