### PR TITLE
Fix typos in Introduction to Dynamic Programming article

### DIFF
--- a/src/dynamic_programming/intro-to-dp.md
+++ b/src/dynamic_programming/intro-to-dp.md
@@ -88,7 +88,7 @@ This approach is called top-down, as we can call the function with a query value
 Until now you've only seen top-down dynamic programming with memoization. However, we can also solve problems with bottom-up dynamic programming. 
 Bottom-up is exactly the opposite of top-down, you start at the bottom (base cases of the recursion), and extend it to more and more values.
 
-To create a bottom-up approach for fibonacci numbers, we initialize the base cases in an array. Then, we simply use the recursive definition on array:
+To create a bottom-up approach for fibonacci numbers, we initialize the base cases in an array. Then, we simply use the recursive definition on the array:
 
 ```cpp
 const int MAXN = 100;
@@ -123,7 +123,7 @@ int f(int n) {
 }
 ```
 
-Note that we've changed the constant from `MAXN` TO `MAX_SAVE`. This is because the total number of elements we need to access is only 3. It no longer scales with the size of input and is, by definition, $O(1)$ memory. Additionally, we use a common trick (using the modulo operator) only maintaining the values we need.
+Note that we've changed the constant from `MAXN` to `MAX_SAVE`. This is because the total number of elements we need to access is only 3. It no longer scales with the size of input and is, by definition, $O(1)$ memory. Additionally, we use a common trick (using the modulo operator) to only maintain the values we need.
 
 That's it. That's the basics of dynamic programming: Don't repeat the work you've done before.
 
@@ -139,7 +139,7 @@ One of the tricks to getting better at dynamic programming is to study some of t
 | Longest Common Subsequence                     | You are given strings $s$ and $t$. Find the length of the longest string that is a subsequence of both $s$ and $t$.                                                                                                            |
 | Longest Path in a Directed Acyclic Graph (DAG) | Finding the longest path in Directed Acyclic Graph (DAG).                                                                                                                                                                      |
 | Longest Palindromic Subsequence                | Finding the Longest Palindromic Subsequence (LPS) of a given string.                                                                                                                                                           |
-| Rod Cutting                                    | Given a rod of length $n$ units, Given an integer array cuts where cuts[i] denotes a position you should perform a cut at. The cost of one cut is the length of the rod to be cut. What is the minimum total cost of the cuts. |
+| Rod Cutting                                    | Given a rod of length $n$ units and an integer array cuts where cuts[i] denotes a position you should perform a cut at. The cost of one cut is the length of the rod to be cut. What is the minimum total cost of the cuts. |
 | Edit Distance                                  | The edit distance between two strings is the minimum number of operations required to transform one string into the other. Operations are ["Add", "Remove", "Replace"]                                                         |
 
 ## Related Topics


### PR DESCRIPTION
Small grammar/typo fixes in `src/dynamic_programming/intro-to-dp.md`. No content or code changes.

- "use the recursive definition on array" → "on **the** array"
- "changed the constant from \`MAXN\` **TO** \`MAX_SAVE\`" → lowercase "to"
- "(using the modulo operator) only maintaining the values" → "(using the modulo operator) **to only maintain** the values"
- Rod Cutting row: "Given a rod of length \$n\$ units, **Given** an integer array cuts" → "units **and** an integer array cuts" (removes the duplicated/broken clause)
