### PR TITLE
Add C++ implementation for composite k case in factorial divisor article

### DIFF
--- a/src/algebra/factorial-divisors.md
+++ b/src/algebra/factorial-divisors.md
@@ -47,3 +47,28 @@ int fact_pow (int n, int k) {
 The same idea can't be applied directly. Instead we can factor $k$, representing it as $k = k_1^{p_1} \cdot \ldots \cdot k_m^{p_m}$. For each $k_i$, we find the number of times it is present in $n!$ using the algorithm described above - let's call this value $a_i$. The answer for composite $k$ will be
 
 $$\min_ {i=1 \ldots m} \dfrac{a_i}{p_i}$$
+
+Factoring $k$ by trial division takes $O(\sqrt{k})$; since $k$ has at most $\log_2 k$ distinct prime factors, the calls to `fact_pow` add another $O(\log_2 k \cdot \log_2 n)$. The overall complexity is therefore $O(\sqrt{k} + \log_2 k \cdot \log_2 n)$.
+
+### Implementation
+
+```cpp
+
+int fact_pow_composite (int n, int k) {
+	int ans = INT_MAX;
+	for (int p = 2; p * p <= k; p++) {
+		if (k % p == 0) {
+			int power = 0;
+			while (k % p == 0) {
+				k /= p;
+				power++;
+			}
+			ans = min(ans, fact_pow(n, p) / power);
+		}
+	}
+	if (k > 1)
+		ans = min(ans, fact_pow(n, k));
+	return ans;
+}
+
+```


### PR DESCRIPTION
## Summary

This PR adds a complete C++ reference implementation for the **composite `k`** case in the **Finding Power of Factorial Divisor** article.

Fixes: #1654 

### Changes

* Added a C++ implementation for handling composite `k`.
* Demonstrated how to:

  * Prime-factorize `k`.
  * Compute the exponent of each prime factor in `n!` using `fact_pow()`.
  * Return the minimum exponent after accounting for each factor's multiplicity.

This complements the existing mathematical explanation and the `fact_pow()` implementation, making the article easier to apply in practice.
