### PR TITLE
Hide sidebar toggle button when the sidebar is in the drawer

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -31,6 +31,7 @@ edit_uri: edit/main/src/
 copyright: Text is available under the <a href="https://github.com/cp-algorithms/cp-algorithms/blob/main/LICENSE">Creative Commons Attribution Share Alike 4.0 International</a> License<br/>Copyright &copy; 2014 - 2025 by <a href="https://github.com/cp-algorithms/cp-algorithms/graphs/contributors">cp-algorithms contributors</a>
 extra_javascript:
   - javascript/config.js
+  - javascript/sidebar-toggle-sync.js
   - https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?features=es6
   - https://unpkg.com/mathjax@3/es5/tex-mml-chtml.js
 extra_css:

--- a/src/javascript/sidebar-toggle-sync.js
+++ b/src/javascript/sidebar-toggle-sync.js
@@ -1,0 +1,24 @@
+// The mkdocs-toggle-sidebar-plugin button has nothing to toggle once the
+// theme collapses the sidebar into the drawer, and it looks like a duplicate
+// of the drawer hamburger next to it. Instead of replicating the theme's
+// breakpoint here, mirror the theme itself: show the button only while the
+// drawer hamburger is hidden.
+document.addEventListener("DOMContentLoaded", () => {
+  const drawer = document.querySelector(".md-header label[for='__drawer']");
+  if (!drawer) return;
+
+  const sync = () => {
+    const toggle = document.querySelector(".mkdocs-toggle-sidebar-button");
+    if (toggle) {
+      toggle.style.display = getComputedStyle(drawer).display === "none" ? "" : "none";
+    }
+  };
+
+  window.addEventListener("resize", sync);
+  const header = document.querySelector(".md-header__inner");
+  if (header) {
+    // The plugin inserts its button after this script runs
+    new MutationObserver(sync).observe(header, { childList: true });
+  }
+  sync();
+});


### PR DESCRIPTION
## Problem

At viewport widths between 960px and 1220px (sidebar already collapsed into the drawer, search bar still expanded), the header shows **two hamburger buttons**: Material's drawer toggle and the mkdocs-toggle-sidebar-plugin button. The plugin button also does nothing useful at those widths, since the sidebar it toggles is hidden.

## Cause

`mkdocs-toggle-sidebar-plugin` 0.1.0 changed the breakpoint below which it hides its header button from `76.1875em` (1220px — where Material switches the sidebar to the drawer and shows its own hamburger) to `60em` (960px). That change fixed upstream issue six-two/mkdocs-toggle-sidebar-plugin#11 for standard Material layouts, where the separate TOC column stays visible down to 60em and the button still has something to toggle. This site uses `toc.integrate`, so there is no separate TOC — between 60em and 76.1875em the button is a dead control that looks like a duplicate hamburger. Our CI installs the plugin unpinned (`scripts/install-mkdocs.sh`), so the deployed site picked up 0.1.0 while older local installs (0.0.7) still behaved correctly.

## Fix

Instead of replicating the theme's breakpoint as a hardcoded media query, a small script (`src/javascript/sidebar-toggle-sync.js`) mirrors the theme itself: the toggle button is shown only while Material's own drawer hamburger is hidden, based on its computed style. This stays correct whatever breakpoint the theme or a future plugin version uses. A MutationObserver on the header handles the plugin inserting its button after the script runs, and a resize listener handles crossing the breakpoint.

Verified by injecting the script into the production site: at 1100px the toggle hides and only the drawer hamburger remains; resizing to 1440px brings the toggle back and the drawer hamburger disappears.

The long-term fix belongs upstream — the plugin's hide-breakpoint should depend on whether `toc.integrate` is active. Until then this keeps the header correct independent of plugin version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)