### PR TITLE
fix extra iteration in SPFA negative cycle condition

### DIFF
--- a/src/graph/bellman_ford.md
+++ b/src/graph/bellman_ford.md
@@ -246,7 +246,7 @@ bool spfa(int s, vector<int>& d) {
                     q.push(to);
                     inqueue[to] = true;
                     cnt[to]++;
-                    if (cnt[to] > n)
+                    if (cnt[to] >= n)
                         return false;  // negative cycle
                 }
             }


### PR DESCRIPTION
This PR fixes a minor off-by-one bound in the SPFA negative cycle detection code, aligning the implementation with the bounds already described in the article text.

### Changes
* **File:** src/graph/bellman_ford.md`
* Changed `if (cnt[to] > n)` to `if (cnt[to] >= n)` in the SPFA code snippet.

The article correctly states that we should "stop the algorithm as soon as some vertex got relaxed for the $n$-th time." However, the code previously used `cnt[to] > n`, which incorrectly forces the algorithm to wait until the $(n+1)$-th time.
In a graph with $n$ vertices, the longest possible shortest path without cycles has exactly $n - 1$ edges. If a vertex gets relaxed (and pushed to the queue) $n$ times, a negative cycle is guaranteed to exist. Catching the cycle at `>= n`  avoids unnecessary work before termination.

No prose or logic structure was altered. This is a single-character logic tweak to implement the description more faithfully and tighten the algorithm's worst-case termination.