### PR TITLE
Fix formatting in Euler path documentation

### DIFF
--- a/src/graph/euler_path.md
+++ b/src/graph/euler_path.md
@@ -56,7 +56,7 @@ It is easy to check the equivalence of these two forms of the algorithm. However
 
 We give here a classical Eulerian cycle problem - the Domino problem.
 
-There are $N$ dominoes, as it is known, on both ends of the Domino one number is written(usually from 1 to 6, but in our case it is not important). You want to put all the dominoes in a row so that the numbers on any two adjacent dominoes, written on their common side, coincide. Dominoes are allowed to turn.
+There are $N$ dominoes, as it is known, on both ends of the Domino one number is written (usually from 1 to 6, but in our case it is not important). You want to put all the dominoes in a row so that the numbers on any two adjacent dominoes, written on their common side, coincide. Dominoes are allowed to turn.
 
 Reformulate the problem. Let the numbers written on the bottoms be the vertices of the graph, and the dominoes be the edges of this graph (each Domino with numbers $(a,b)$ are the edges $(a,b)$ and $(b, a)$). Then our problem is reduced to the problem of finding the Eulerian path in this graph.
 


### PR DESCRIPTION
Corrected formatting of the text in the Domino problem section. Added space after "written" which was missing previously.