### PR TITLE
improve .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,8 @@ target
 *.swp
 *.sublime-project
 *.sublime-workspace
+.vscode/
+__pycache__/
 converted.html
 converted.pdf
 /output


### PR DESCRIPTION
## Add `.vscode/` and `__pycache__/` to .gitignore

Both directories are generated during normal local development: `__pycache__/`
by the `hooks.py` module and the test scripts, and `.vscode/` by the editor.
Ignoring them keeps `git status` clean and avoids accidentally committing
build artifacts.
