### PR TITLE
Fix index in CRT direct construction

### DIFF
--- a/src/algebra/chinese-remainder-theorem.md
+++ b/src/algebra/chinese-remainder-theorem.md
@@ -101,7 +101,7 @@ then you can compute $b_3 := a \pmod{m_1 m_2 m_3}$ using the congruences $a \equ
 
 A direct construction similar to Lagrange interpolation is possible.
 
-Let $M_i := \prod_{i \neq j} m_j$, the product of all moduli but $m_i$, and $N_i$ the modular inverses $N_i := M_i^{-1} \bmod{m_i}$.
+Let $M_i := \prod_{j \neq i} m_j$, the product of all moduli but $m_i$, and $N_i$ the modular inverses $N_i := M_i^{-1} \bmod{m_i}$.
 Then a solution to the system of congruences is:
 
 $$a \equiv \sum_{i=1}^k a_i M_i N_i \pmod{m_1 m_2 \cdots m_k}$$


### PR DESCRIPTION
## Summary

Fix the index variable in the direct-construction definition of `M_i`:

- from `M_i := \prod_{i \neq j} m_j`
- to `M_i := \prod_{j \neq i} m_j`

The surrounding text already defines `M_i` as the product of all moduli except `m_i`, and the implementation uses that intended definition.