### PR TITLE
Fix extra parenthesis in Fenwick range-update pseudocode

### DIFF
--- a/src/data_structures/fenwick.md
+++ b/src/data_structures/fenwick.md
@@ -400,7 +400,7 @@ def range_add(l, r, x):
     add(B1, l, x)
     add(B1, r+1, -x)
     add(B2, l, x*(l-1))
-    add(B2, r+1, -x*r))
+    add(B2, r+1, -x*r)
 ```
 After the range update $(l, r, x)$ the range sum query should return the following values:
 


### PR DESCRIPTION
The `range_add` pseudocode in the Fenwick Tree article has one extra closing parenthesis in its last `B2` update:

`add(B2, r+1, -x*r))`

This PR removes only that extra `)` so the pseudocode is syntactically consistent with the complete version shown later in the same section.

Only `src/data_structures/fenwick.md` is changed.