### PR TITLE
Fix bridge parallel-edge explanation

### DIFF
--- a/src/graph/bridge-searching.md
+++ b/src/graph/bridge-searching.md
@@ -93,7 +93,7 @@ Main function is `find_bridges`; it performs necessary initialization and starts
 
 Function `IS_BRIDGE(a, b)` is some function that will process the fact that edge $(a, b)$ is a bridge, for example, print it.
 
-Note that this implementation malfunctions if the graph has multiple edges, since it ignores them. Of course, multiple edges will never be a part of the answer, so `IS_BRIDGE` can check additionally that the reported bridge is not a multiple edge. Alternatively it's possible to pass to `dfs` the index of the edge used to enter the vertex instead of the parent vertex (and store the indices of all vertices).
+The `parent_skipped` flag makes this implementation handle multiple edges between a vertex and its parent: it skips only the DFS tree edge used to enter the vertex, while an additional parallel edge is processed as a back edge. Alternatively, it's possible to pass to `dfs` the index of the edge used to enter the vertex instead of the parent vertex (and store the indices of all edges).
 
 ## Practice Problems
 


### PR DESCRIPTION
## Summary

Update the paragraph after the offline bridge-searching implementation so it matches the current code.

The implementation already uses `parent_skipped`, which skips only the DFS tree edge back to the parent. A second parallel edge is therefore processed as a back edge, so the previous statement that the implementation "malfunctions if the graph has multiple edges" is stale.

The revised paragraph also fixes the edge-index alternative to say that edge indices, rather than vertex indices, need to be stored.

## Scope

- documentation only;
- no algorithm or code changes;
- one paragraph in `src/graph/bridge-searching.md`.

I also searched the repository's existing issues and PRs for the stale multi-edge wording and did not find a duplicate.