### PR TITLE
Fix LCA and HLD documentation issues

### DIFF
--- a/src/graph/hld.md
+++ b/src/graph/hld.md
@@ -108,8 +108,8 @@ $\mathcal{O}(\log n)$ per path for $\mathcal{O}(\log n)$ paths leads to a comple
 
 Certain parts of the above discussed approach can be modified to make implementation easier without losing efficiency.
 
-* The definition of **heavy edge** can be changed to **the edge leading to the child with largest subtree**, with ties broken arbitrarily. This may result is some light edges being converted to heavy, which means some heavy paths will combine to form a single path, but all heavy paths will remain disjoint. It is also still guaranteed that going down a light edge reduces subtree size to half or less.
-* Instead of a building segment tree over every heavy path, a single segment tree can be used with disjoint segments allocated to each heavy path.
+* The definition of **heavy edge** can be changed to **the edge leading to the child with largest subtree**, with ties broken arbitrarily. This may result in some light edges being converted to heavy, which means some heavy paths will combine to form a single path, but all heavy paths will remain disjoint. It is also still guaranteed that going down a light edge reduces subtree size to half or less.
+* Instead of building a segment tree over every heavy path, a single segment tree can be used with disjoint segments allocated to each heavy path.
 * It has been mentioned that answering queries requires calculation of the LCA. While LCA can be calculated separately, it is also possible to integrate LCA calculation in the process of answering queries.
 
 To perform heavy-light decomposition:
@@ -167,7 +167,7 @@ To answer queries on paths, for example the maximum query discussed, we can do s
 
 ```cpp
 int query(int a, int b) {
-    int res = 0;
+    int res = segment_tree_query(pos[a], pos[a]);
     for (; head[a] != head[b]; b = parent[head[b]]) {
         if (depth[head[a]] > depth[head[b]])
             swap(a, b);

--- a/src/graph/lca_binary_lifting.md
+++ b/src/graph/lca_binary_lifting.md
@@ -17,7 +17,7 @@ The algorithm described in this article will need $O(N \log N)$ for preprocessin
 
 For each node we will precompute its ancestor above it, its ancestor two nodes above, its ancestor four above, etc.
 Let's store them in the array `up`, i.e. `up[i][j]` is the `2^j`-th ancestor above the node `i` with `i=1...N`, `j=0...ceil(log(N))`.
-These information allow us to jump from any node to any ancestor above it in $O(\log N)$ time.
+This information allows us to jump from any node to any ancestor above it in $O(\log N)$ time.
 We can compute this array using a [DFS](depth-first-search.md) traversal of the tree.
 
 For each node we will also remember the time of the first visit of this node (i.e. the time when the DFS discovers the node), and the time when we left it (i.e. after we visited all children and exit the DFS function).
@@ -38,7 +38,7 @@ Clearly after doing this for all non-negative `i` the node `u` will be the desir
 
 Now, obviously, the answer to LCA will be `up[u][0]` - i.e., the smallest node among the ancestors of the node `u`, which is also an ancestor of `v`.
 
-So answering a LCA query will iterate `i` from `ceil(log(N))` to `0` and checks in each iteration if one node is the ancestor of the other.
+So answering a LCA query will iterate `i` from `ceil(log(N))` to `0` and check in each iteration if one node is the ancestor of the other.
 Consequently each query can be answered in $O(\log N)$.
 
 ## Implementation

--- a/src/graph/lca_farachcoltonbender.md
+++ b/src/graph/lca_farachcoltonbender.md
@@ -20,7 +20,7 @@ We use the classical reduction of the LCA problem to the RMQ problem.
 We traverse all nodes of the tree with [DFS](depth-first-search.md) and keep an array with all visited nodes and the heights of these nodes. 
 The LCA of two nodes $u$ and $v$ is the node between the occurrences of $u$ and $v$ in the tour, that has the smallest height.
 
-In the following picture you can see a possible Euler-Tour of a graph and in the list below you can see the visited nodes and their heights.
+In the following picture you can see a possible Euler-Tour of a tree and in the list below you can see the visited nodes and their heights.
 
 <div style="text-align: center;">
   <img src="LCA_Euler.png" alt="LCA_Euler_Tour">

--- a/src/graph/lca_farachcoltonbender.md
+++ b/src/graph/lca_farachcoltonbender.md
@@ -50,7 +50,7 @@ You can build the table easily in $O(N \log N)$ by noting that $T[i][j] = \min(T
 
 How can we answer a query RMQ in $O(1)$ using this data structure?
 Let the received query be $[l, r]$, then the answer is $\min(T[l][\text{sz}], T[r-2^{\text{sz}}+1][\text{sz}])$, where $\text{sz}$ is the biggest exponent such that $2^{\text{sz}}$ is not bigger than the range length $r-l+1$. 
-Indeed we can take the range $[l, r]$ and cover it two segments of length $2^{\text{sz}}$ - one starting in $l$ and the other ending in $r$.
+Indeed we can take the range $[l, r]$ and cover it with two segments of length $2^{\text{sz}}$ - one starting in $l$ and the other ending in $r$.
 These segments overlap, but this doesn't interfere with our computation.
 To really achieve the time complexity of $O(1)$ per query, we need to know the values of $\text{sz}$ for all possible lengths from $1$ to $N$.
 But this can be easily precomputed.


### PR DESCRIPTION
## Summary

Fix a handful of documentation issues found in the LCA and heavy-light decomposition articles:

- fix two grammar errors in the binary-lifting LCA explanation;
- clarify that the Farach-Colton–Bender Euler-tour figure is a tree, not a generic graph;
- add the missing `with` in the Farach-Colton–Bender RMQ explanation;
- fix two grammar errors in the HLD implementation notes;
- make the HLD maximum-query example work when all values on the queried path are negative by initializing `res` from an actual path value instead of `0`.

The previous `res = 0` implicitly assumes non-negative values, but the article does not impose that restriction. Initializing from the value at endpoint `a` keeps the example generic without introducing a numeric sentinel.

## Scope

- three English documentation files only;
- no translation/i18n changes;
- no change to the HLD algorithm or its asymptotic complexity.

I searched the open issues and PRs for the distinctive HLD negative-maximum problem and the LCA wording errors and did not find a duplicate.