### PR TITLE
Fix maximum-flow terminology and min-cost flow infeasibility wording

### DIFF
--- a/src/graph/edmonds_karp.md
+++ b/src/graph/edmonds_karp.md
@@ -6,7 +6,7 @@ e_maxx_link: edmonds_karp
 
 # Maximum flow - Ford-Fulkerson and Edmonds-Karp
 
-The Edmonds-Karp algorithm is an implementation of the Ford-Fulkerson method for computing a maximal flow in a flow network.
+The Edmonds-Karp algorithm is an implementation of the Ford-Fulkerson method for computing a maximum flow in a flow network.
 
 ## Flow network
 
@@ -33,7 +33,7 @@ It is easy to see that the following equation holds:
 $$\sum_{(s, u) \in E} f((s, u)) = \sum_{(u, t) \in E} f((u, t))$$
 
 A good analogy for a flow network is the following visualization:
-We represent edges as water pipes, the capacity of an edge is the maximal amount of water that can flow through the pipe per second, and the flow of an edge is the amount of water that currently flows through the pipe per second.
+We represent edges as water pipes, the capacity of an edge is the maximum amount of water that can flow through the pipe per second, and the flow of an edge is the amount of water that currently flows through the pipe per second.
 This motivates the first flow condition. There cannot flow more water through a pipe than its capacity.
 The vertices act as junctions, where water comes out of some pipes, and then, these vertices distribute the water in some way to other pipes.
 This also motivates the second flow condition.
@@ -48,15 +48,15 @@ The first value of each edge represents the flow, which is initially 0, and the 
 </div>
 
 The value of the flow of a network is the sum of all the flows that get produced in the source $s$, or equivalently to the sum of all the flows that are consumed by the sink $t$.
-A **maximal flow** is a flow with the maximal possible value.
-Finding this maximal flow of a flow network is the problem that we want to solve.
+A **maximum flow** is a flow with the maximum possible value.
+Finding this maximum flow of a flow network is the problem that we want to solve.
 
 In the visualization with water pipes, the problem can be formulated in the following way:
 how much water can we push through the pipes from the source to the sink?
 
-The following image shows the maximal flow in the flow network.
+The following image shows the maximum flow in the flow network.
 <div style="text-align: center;">
-  <img src="Flow9.png" alt="Maximal flow">
+  <img src="Flow9.png" alt="Maximum flow">
 </div>
 
 ## Ford-Fulkerson method
@@ -73,7 +73,7 @@ Then we look for an **augmenting path** from $s$ to $t$.
 An augmenting path is a simple path in the residual graph where residual capacity is positive for all the edges along that path.
 If such a path is found, then we can increase the flow along these edges.
 We keep on searching for augmenting paths and increasing the flow.
-Once an augmenting path doesn't exist anymore, the flow is maximal.
+Once an augmenting path doesn't exist anymore, the flow is maximum.
 
 Let us specify in more detail, what increasing the flow along an augmenting path means.
 Let $C$ be the smallest residual capacity of the edges in the path.
@@ -121,22 +121,22 @@ Instead of sending a flow of 3 from $D$ to $A$, we only send 2 and compensate th
   <img src="Flow9.png" alt="Network after fourth path">
 </div>
 
-Now, it is impossible to find an augmenting path between $s$ and $t$, therefore this flow of $10$ is the maximal possible.
-We have found the maximal flow.
+Now, it is impossible to find an augmenting path between $s$ and $t$, therefore this flow of $10$ is the maximum possible.
+We have found the maximum flow.
 
 It should be noted, that the Ford-Fulkerson method doesn't specify a method of finding the augmenting path.
 Possible approaches are using [DFS](depth-first-search.md) or [BFS](breadth-first-search.md) which both work in $O(E)$.
 If all the capacities of the network are integers, then for each augmenting path the flow of the network increases by at least 1 (for more details see [Integral flow theorem](#integral-theorem)).
-Therefore, the complexity of Ford-Fulkerson is $O(E F)$, where $F$ is the maximal flow of the network.
+Therefore, the complexity of Ford-Fulkerson is $O(E F)$, where $F$ is the maximum flow of the network.
 In the case of rational capacities, the algorithm will also terminate, but the complexity is not bounded.
-In the case of irrational capacities, the algorithm might never terminate, and might not even converge to the maximal flow.
+In the case of irrational capacities, the algorithm might never terminate, and might not even converge to the maximum flow.
 
 ## Edmonds-Karp algorithm
 
 Edmonds-Karp algorithm is just an implementation of the Ford-Fulkerson method that uses [BFS](breadth-first-search.md) for finding augmenting paths.
 The algorithm was first published by Yefim Dinitz in 1970, and later independently published by Jack Edmonds and Richard Karp in 1972.
 
-The complexity can be given independently of the maximal flow.
+The complexity can be given independently of the maximum flow.
 The algorithm runs in $O(V E^2)$ time, even for irrational capacities.
 The intuition is, that every time we find an augmenting path one of the edges becomes saturated, and the distance from the edge to $s$ will be longer if it appears later again in an augmenting path.
 The length of the simple paths is bounded by $V$.
@@ -146,7 +146,7 @@ The length of the simple paths is bounded by $V$.
 The matrix `capacity` stores the capacity for every pair of vertices.
 `adj` is the adjacency list of the **undirected graph**, since we also have to use the reversed of directed edges when we are looking for augmenting paths.
 
-The function `maxflow` will return the value of the maximal flow.
+The function `maxflow` will return the value of the maximum flow.
 During the algorithm, the matrix `capacity` will actually store the residual capacity of the network.
 The value of the flow in each edge will actually not be stored, but it is easy to extend the implementation - by using an additional matrix - to also store the flow and return it.
 

--- a/src/graph/min_cost_flow.md
+++ b/src/graph/min_cost_flow.md
@@ -56,7 +56,7 @@ The case of an undirected graph or a multigraph doesn't differ conceptually from
 The algorithm will also work on these graphs.
 However it becomes a little more difficult to implement it.
 
-An **undirected edge** $(i, j)$ is actually the same as two oriented edges $(i, j)$ and $(j, i)$ with the same capacity and values.
+An **undirected edge** $(i, j)$ is actually the same as two oriented edges $(i, j)$ and $(j, i)$ with the same capacity and cost.
 Since the above-described minimum-cost flow algorithm generates a back edge for each directed edge, so it splits the undirected edge into $4$ directed edges, and we actually get a **multigraph**.
 
 How do we deal with **multiple edges**?

--- a/src/graph/min_cost_flow.md
+++ b/src/graph/min_cost_flow.md
@@ -14,7 +14,7 @@ For a given value $K$, we have to find a flow of this quantity, and among all fl
 This task is called **minimum-cost flow problem**.
 
 Sometimes the task is given a little differently:
-you want to find the maximum flow, and among all maximal flows we want to find the one with the least cost.
+you want to find the maximum flow, and among all maximum flows we want to find the one with the least cost.
 This is called the **minimum-cost maximum-flow problem**.
 
 Both these problems can be solved effectively with the algorithm of successive shortest paths.
@@ -37,13 +37,13 @@ for each edge $(i, j)$ we add the **reverse edge** $(j, i)$ to the network with 
 Since, according to our restrictions, the edge $(j, i)$ was not in the network before, we still have a network that is not a multigraph (graph with multiple edges).
 In addition we will always keep the condition $F_{j i} = -F_{i j}$ true during the steps of the algorithm.
 
-We define the **residual network** for some fixed flow $F$ as follow (just like in the Ford-Fulkerson algorithm):
+We define the **residual network** for some fixed flow $F$ as follows (just like in the Ford-Fulkerson algorithm):
 the residual network contains only unsaturated edges (i.e. edges in which $F_{i j} < U_{i j}$), and the residual capacity of each such edge is $R_{i j} = U_{i j} - F_{i j}$.
 
-Now we can talk about the **algorithms** to compute the minimum-cost flow.
+Now we can talk about the **algorithm** to compute the minimum-cost flow.
 At each iteration of the algorithm we find the shortest path in the residual graph from $s$ to $t$.
 In contrast to Edmonds-Karp, we look for the shortest path in terms of the cost of the path instead of the number of edges.
-If there doesn't exists a path anymore, then the algorithm terminates, and the stream $F$ is the desired one.
+If no such path exists anymore, then the algorithm terminates. If the current flow has not yet reached $K$, then no flow of value $K$ exists; otherwise $F$ is the desired flow.
 If a path was found, we increase the flow along it as much as possible (i.e. we find the minimal residual capacity $R$ of the path, and increase the flow by it, and reduce the back edges by the same amount).
 If at some point the flow reaches the value $K$, then we stop the algorithm (note that in the last iteration of the algorithm it is necessary to increase the flow by only such an amount so that the final flow value doesn't surpass $K$).
 


### PR DESCRIPTION
## Summary

Fix documentation issues in the network-flow articles:

- use **maximum flow** consistently in the Ford-Fulkerson / Edmonds-Karp article instead of the mathematically distinct/ambiguous **maximal flow** wording;
- clarify the successive-shortest-path stopping condition for a requested flow value `K`: if the residual network has no `s`-to-`t` path before the flow reaches `K`, then no flow of value `K` exists;
- clarify the undirected-edge explanation in the min-cost-flow article: the two directed edges have the same capacity and **cost**, rather than the ambiguous wording “same capacity and values”.

The min-cost-flow changes also fix the nearby `stream F` typo and two small grammar issues (`as follow`, plural `algorithms`).

## Scope

- `src/graph/edmonds_karp.md` and `src/graph/min_cost_flow.md` only;
- English documentation only;
- no translation/i18n files;
- no algorithm/code changes.

The fixed-`K` wording now matches the implementation below it, which returns `-1` when `flow < K` after no augmenting path remains.

I searched the open issues and pull requests for the distinctive maximum/maximal-flow terminology and fixed-`K` infeasibility wording and did not find a duplicate.