### PR TITLE
Fix matching and Hungarian documentation wording

### DIFF
--- a/src/graph/hungarian-algorithm.md
+++ b/src/graph/hungarian-algorithm.md
@@ -28,7 +28,7 @@ We also note that by analogy with the search for a **minimum** solution, one can
 
 The algorithm was developed and published by Harold **Kuhn** in 1955. Kuhn himself gave it the name "Hungarian" because it was based on the earlier work by Hungarian mathematicians Dénes Kőnig and Jenő Egerváry.<br>
 In 1957, James **Munkres** showed that this algorithm runs in (strictly) polynomial time, independently from the cost.<br>
-Therefore, in literature, this algorithm is known not only as the "Hungarian", but also as the "Kuhn-Mankres algorithm" or "Mankres algorithm".<br>
+Therefore, in literature, this algorithm is known not only as the "Hungarian", but also as the "Kuhn-Munkres algorithm" or "Munkres algorithm".<br>
 However, it was recently discovered in 2006 that the same algorithm was invented **a century before Kuhn** by the German mathematician Carl Gustav **Jacobi**. His work, _About the research of the order of a system of arbitrary ordinary differential equations_, which was published posthumously in 1890, contained, among other findings, a polynomial algorithm for solving the assignment problem. Unfortunately, since the publication was in Latin, it went unnoticed among mathematicians.
 
 It is also worth noting that Kuhn's original algorithm had an asymptotic complexity of $\mathcal{O}(n^4)$, and only later Jack **Edmonds** and Richard **Karp** (and independently **Tomizawa**) showed how to improve it to an asymptotic complexity of $\mathcal{O}(n^3)$.
@@ -75,7 +75,7 @@ All edges of the matching $M$ are oriented in the direction from the right part 
 Recall (from the terminology of searching for matchings) that a vertex is called saturated if an edge of the current matching is adjacent to it. A vertex that is not adjacent to any edge of the current matching is called unsaturated. A path of odd length, in which the first edge does not belong to the matching, and for all subsequent edges there is an alternating belonging to the matching (belongs/does not belong) - is called an augmenting path.
 From all unsaturated vertices in the left part, a [depth-first](depth-first-search.md) or [breadth-first](breadth-first-search.md) traversal is started. If, as a result of the search, it was possible to reach an unsaturated vertex of the right part, we have found an augmenting path from the left part to the right one. If we include odd edges of the path and remove the even ones in the matching (i.e. include the first edge in the matching, exclude the second, include the third, etc.), then we will increase the matching cardinality by one.
 
-If there was no augmenting path, then the current matching $M$ is maximal in the graph $H$.
+If there was no augmenting path, then the current matching $M$ is maximum in the graph $H$.
 
 **Step 3.** If at the current step, it is not possible to increase the cardinality of the current matching, then a recalculation of the potential is performed in such a way that, at the next steps, there will be more opportunities to increase the matching.
 
@@ -241,9 +241,9 @@ int cost = -v[0];
 
 The Hungarian algorithm can be seen as the [Successive Shortest Path Algorithm](min_cost_flow.md), adapted for the assignment problem. Without going into the details, let's provide an intuition regarding the connection between them.
 
-The Successive Path algorithm uses a modified version of Johnson's algorithm as reweighting technique. This one is divided into four steps:
+The Successive Shortest Path algorithm uses a modified version of Johnson's algorithm as reweighting technique. This one is divided into four steps:
 
-- Use the [Bellman-Ford](bellman_ford.md) algorithm, starting from the sink $s$ and, for each node, find the minimum weight $h(v)$ of a path from $s$ to $v$.
+- Use the [Bellman-Ford](bellman_ford.md) algorithm, starting from the source $s$ and, for each node, find the minimum weight $h(v)$ of a path from $s$ to $v$.
 
 For every step of the main algorithm:
 

--- a/src/graph/kuhn_maximum_bipartite_matching.md
+++ b/src/graph/kuhn_maximum_bipartite_matching.md
@@ -36,7 +36,7 @@ That is, $A \oplus B = (A - B) \cup (B - A) = (A \cup B) - (A \cap B)$.
 ### Berge's lemma
 
 This lemma was proven by the French mathematician **Claude Berge** in 1957, although it already was observed by the Danish mathematician **Julius Petersen** in 1891 and 
-the Hungarian mathematician **Denés Kőnig** in 1931.
+the Hungarian mathematician **Dénes Kőnig** in 1931.
 
 #### Formulation 
 A matching $M$ is maximum $\Leftrightarrow$ there is no augmenting path relative to the matching $M$.
@@ -80,7 +80,7 @@ The algorithm is more convenient to describe if we assume that the input graph i
 that the input graph is not explicitly split into two parts).
 
 The algorithm looks at all the vertices $v$ of the first part of the graph: $v = 1 \ldots n_1$. If the current vertex $v$ is already saturated with the current matching 
-(i.e., some edge adjacent to it has already been selected), then skip this vertex. Otherwise, the algorithm tries to saturate this vertex, for which it starts 
+(i.e., some edge adjacent to it has already been selected), then it can be skipped. Otherwise, the algorithm tries to saturate this vertex, for which it starts 
 a search for an augmenting path starting from this vertex.
 
 The search for an augmenting path is carried out using a special depth-first or breadth-first traversal (usually depth-first traversal is used for ease of implementation). 
@@ -113,8 +113,7 @@ Let us present here an implementation of the above algorithm based on depth-firs
 This implementation is very concise, and perhaps it should be remembered in this form.
 
 Here $n$ is the number of vertices in the first part, $k$ - in the second part, $g[v]$ is the list of edges from the top of the first part (i.e. the list of numbers of the 
-vertices to which these edges lead from $v$). The vertices in both parts are numbered independently, i.e. vertices in the first part are numbered $1 \ldots n$, and those in the 
-second are numbered $1 \ldots k$.
+vertices to which these edges lead from $v$). In the implementation below, the vertices in both parts are indexed independently from zero: the first part uses indices $0 \ldots n-1$, and the second part uses $0 \ldots k-1$. The printed output adds one to these indices.
 
 Then there are two auxiliary arrays: $\rm mt$ and $\rm used$. The first - $\rm mt$ - contains information about the current matching. For convenience of programming, 
 this information is contained only for the vertices of the second part: $\textrm{mt[} i \rm]$ - this is the number of the vertex of the first part connected by an edge with the vertex $i$ of 

--- a/src/graph/kuhn_maximum_bipartite_matching.md
+++ b/src/graph/kuhn_maximum_bipartite_matching.md
@@ -122,10 +122,10 @@ the second part (or $-1$, if no matching edge comes out of it). The second array
 (it is needed just so that the depth-first traversal does not enter the same vertex twice).
 
 A function $\textrm{try_kuhn}$ is a depth-first traversal. It returns $\rm true$ if it was able to find an augmenting path from the vertex $v$, and it is considered that this 
-function has already performed the alternation of matching along the found chain.
+function has already performed the alternation of matching along the found path.
 
 Inside the function, all the edges outgoing from the vertex $v$ of the first part are scanned, and then the following is checked: if this edge leads to an unsaturated vertex 
-$to$, or if this vertex $to$ is saturated, but it is possible to find an increasing chain by recursively starting from $\textrm{mt[}to \rm ]$, then we say that we have found an 
+$to$, or if this vertex $to$ is saturated, but it is possible to find an augmenting path by recursively starting from $\textrm{mt[}to \rm ]$, then we say that we have found an 
 augmenting path, and before returning from the function with the result $\rm true$, we alternate the current edge: we redirect the edge adjacent to $to$ to the vertex $v$.
 
 The main program first indicates that the current matching is empty (the list $\rm mt$ is filled with numbers $-1$). Then the vertex $v$ of the first part is searched by $\textrm{try_kuhn}$, 
@@ -171,7 +171,7 @@ int main() {
 We repeat once again that Kuhn's algorithm is easy to implement in such a way that it works on graphs that are known to be bipartite, but their explicit splitting into two parts 
 has not been given. In this case, it will be necessary to abandon the convenient division into two parts, and store all the information for all vertices of the graph. For this, 
 an array of lists $g$ is now specified not only for the vertices of the first part, but for all the vertices of the graph (of course, now the vertices of both parts are numbered 
-in a common numbering - from $1$ to $n$). Arrays $\rm mt$ and are $\rm used$ are now also defined for the vertices of both parts, and, accordingly, they need to be kept in this state.
+in a common numbering - from $1$ to $n$). Arrays $\rm mt$ and $\rm used$ are now also defined for the vertices of both parts, and, accordingly, they need to be kept in this state.
 
 ### Improved implementation
 


### PR DESCRIPTION
## Summary

Fix a few documentation issues in the bipartite-matching and Hungarian-algorithm articles:

- use **augmenting path** consistently in the Kuhn implementation discussion instead of `increasing chain` / `found chain`;
- fix the malformed `Arrays mt and are used` sentence;
- correct the mathematician's name from `Denés Kőnig` to **Dénes Kőnig**;
- clarify that an already saturated first-part vertex **can** be skipped in the described Kuhn variant, rather than presenting the skip as a required condition;
- make the standard Kuhn implementation prose match the snippet's actual **0-based internal indexing** and note that the printed output adds one;
- correct `Mankres` to **Munkres** in the Hungarian algorithm's historical names;
- after the article establishes that there is no augmenting path, call the matching **maximum** rather than merely `maximal`, consistent with Berge's lemma and the terminology distinguished in the Kuhn article;
- use the full name **Successive Shortest Path algorithm** and correct `sink s` to **source s** in the shortest-path connection section.

## Scope

- `src/graph/kuhn_maximum_bipartite_matching.md` and `src/graph/hungarian-algorithm.md` only;
- English documentation only;
- no algorithm/code changes;
- no translation/i18n files.

I verified these wordings on the current `main` branch and searched the open issues/PRs for the distinctive `Mankres`, `increasing chain`, `sink s`, and `maximal in the graph` phrases without finding a duplicate.