### PR TITLE
Fix cycle-detection complexity and Euler path implementation notes

### DIFF
--- a/src/graph/euler_path.md
+++ b/src/graph/euler_path.md
@@ -56,9 +56,9 @@ It is easy to check the equivalence of these two forms of the algorithm. However
 
 We give here a classical Eulerian cycle problem - the Domino problem.
 
-There are $N$ dominoes, as it is known, on both ends of the Domino one number is written (usually from 1 to 6, but in our case it is not important). You want to put all the dominoes in a row so that the numbers on any two adjacent dominoes, written on their common side, coincide. Dominoes are allowed to turn.
+There are $N$ dominoes, as it is known, on both ends of the domino one number is written (usually from 1 to 6, but in our case it is not important). You want to put all the dominoes in a row so that the numbers on any two adjacent dominoes, written on their common side, coincide. Dominoes are allowed to turn.
 
-Reformulate the problem. Let the numbers written on the bottoms be the vertices of the graph, and the dominoes be the edges of this graph (each Domino with numbers $(a,b)$ are the edges $(a,b)$ and $(b, a)$). Then our problem is reduced to the problem of finding the Eulerian path in this graph.
+Reformulate the problem. Let the numbers written on the bottoms be the vertices of the graph, and the dominoes be the edges of this graph (each domino with numbers $(a,b)$ are the edges $(a,b)$ and $(b,a)$). Then our problem is reduced to the problem of finding the Eulerian path in this graph.
 
 ## Implementation
 

--- a/src/graph/euler_path.md
+++ b/src/graph/euler_path.md
@@ -6,8 +6,8 @@ e_maxx_link: euler_path
 ---
 # Finding the Eulerian path in $O(M)$
 
-A Eulerian path is a path in a graph that passes through all of its edges exactly once.
-A Eulerian cycle is a Eulerian path that is a cycle.
+An Eulerian path is a path in a graph that passes through all of its edges exactly once.
+An Eulerian cycle is an Eulerian path that is a cycle.
 
 The problem is to find the Eulerian path in an **undirected multigraph with loops**.
 
@@ -15,7 +15,7 @@ The problem is to find the Eulerian path in an **undirected multigraph with loop
 
 First we can check if there is an Eulerian path.
 We can use the following theorem. An Eulerian cycle exists if and only if the degrees of all vertices are even.
-And an Eulerian path exists if and only if the number of vertices with odd degrees is two (or zero, in the case of the existence of a Eulerian cycle).
+And an Eulerian path exists if and only if the number of vertices with odd degrees is two (or zero, in the case of the existence of an Eulerian cycle).
 In addition, of course, the graph must be sufficiently connected (i.e., if you remove all isolated vertices from it, you should get a connected graph).
 
 To find the Eulerian path / Eulerian cycle we can use the following strategy:
@@ -62,7 +62,7 @@ Reformulate the problem. Let the numbers written on the bottoms be the vertices 
 
 ## Implementation
 
-The program below searches for and outputs a Eulerian loop or path in a graph, or outputs $-1$ if it does not exist.
+The program below searches for and outputs an Eulerian cycle or path in a graph, or outputs $-1$ if it does not exist.
 
 First, the program checks the degree of vertices: if there are no vertices with an odd degree, then the graph has an Euler cycle, if there are $2$ vertices with an odd degree, then in the graph there is only an Euler path (but no Euler cycle), if there are more than $2$ such vertices, then in the graph there is no Euler cycle or Euler path.
 To find the Euler path (not a cycle), let's do this: if $V1$ and $V2$ are two vertices of odd degree, then just add an edge $(V1, V2)$, in the resulting graph we find the Euler cycle (it will obviously exist), and then remove the "fictitious" edge $(V1, V2)$ from the answer.
@@ -72,11 +72,12 @@ Finally, the program takes into account that there can be isolated vertices in t
 Notice that we use an adjacency matrix in this problem.
 Also this implementation handles finding the next with brute-force, which requires to iterate over the complete row in the matrix over and over.
 A better way would be to store the graph as an adjacency list, and remove edges in $O(1)$ and mark the reversed edges in separate list.
-This way we can achieve an $O(N)$ algorithm.
+This way we can achieve an $O(M)$ algorithm.
 
 ```cpp
 int main() {
     int n;
+    cin >> n;
     vector<vector<int>> g(n, vector<int>(n));
     // reading the graph in the adjacency matrix
 

--- a/src/graph/finding-cycle.md
+++ b/src/graph/finding-cycle.md
@@ -1,14 +1,14 @@
 ---
-title: Checking a graph for acyclicity and finding a cycle in O(M)
+title: Checking a graph for acyclicity and finding a cycle in O(N+M)
 tags:
   - Translated
 e_maxx_link: finding_cycle
 ---
-# Checking a graph for acyclicity and finding a cycle in $O(M)$
+# Checking a graph for acyclicity and finding a cycle in $O(N+M)$
 
 Consider a directed or undirected graph without loops and multiple edges. We have to check whether it is acyclic, and if it is not, then find any cycle.
 
-We can solve this problem by using [Depth First Search](depth-first-search.md) in $O(M)$ where $M$ is number of edges.
+We can solve this problem by using [Depth First Search](depth-first-search.md) in $O(N+M)$, where $N$ is the number of vertices and $M$ is the number of edges.
 
 ## Algorithm
 


### PR DESCRIPTION
## Summary

Fix a few issues in the cycle-detection and Eulerian-path articles:

- state the cycle-detection DFS complexity as **O(N+M)** rather than O(M), since the implementation also scans all vertices to start DFS in each component;
- fix the Eulerian-path implementation snippet so `n` is read before it is used to size the adjacency matrix;
- correct the adjacency-list complexity from **O(N)** to **O(M)**, matching the article's edge-based notation and linear-time claim;
- fix a few nearby `A Eulerian` / `a Eulerian` grammar issues;
- normalize `domino` capitalization in the Domino reduction and remove the inconsistent space in `$(b,a)$` notation.

## Scope

- `src/graph/finding-cycle.md` and `src/graph/euler_path.md` only;
- English documentation/source snippet only;
- no translation/i18n files.

I verified the issues on the current `main` branch and searched open issues/PRs for the cycle-complexity and Euler implementation wording without finding a duplicate.