### PR TITLE
Fix LIS sentinel range and index notation

### DIFF
--- a/src/dynamic_programming/longest_increasing_subsequence.md
+++ b/src/dynamic_programming/longest_increasing_subsequence.md
@@ -191,8 +191,8 @@ After processing all the elements of $a[]$ the length of the desired subsequence
 ```{.cpp file=lis_method2_n2}
 int lis(vector<int> const& a) {
     int n = a.size();
-    const int INF = 1e9;
-    vector<int> d(n+1, INF);
+    const long long INF = (1LL << 60);
+    vector<long long> d(n+1, INF);
     d[0] = -INF;
 
     for (int i = 0; i < n; i++) {
@@ -214,7 +214,7 @@ int lis(vector<int> const& a) {
 We now make two important observations.
 
 1.  The array $d$ will always be sorted: 
-    $d[l-1] < d[l]$ for all $i = 1 \dots n$.
+    $d[l-1] < d[l]$ for all $l = 1 \dots n$.
 
     This is trivial, as you can just remove the last element from the increasing subsequence of length $l$, and you get a increasing subsequence of length $l-1$ with a smaller ending number.
 
@@ -233,8 +233,8 @@ This gives us the improved $O(n \log n)$ implementation:
 ```{.cpp file=lis_method2_nlogn}
 int lis(vector<int> const& a) {
     int n = a.size();
-    const int INF = 1e9;
-    vector<int> d(n+1, INF);
+    const long long INF = (1LL << 60);
+    vector<long long> d(n+1, INF);
     d[0] = -INF;
 
     for (int i = 0; i < n; i++) {


### PR DESCRIPTION
## Summary

Fix two correctness/notation issues in `src/dynamic_programming/longest_increasing_subsequence.md`:

- use sentinels outside the full `int` input range in the two DP-array implementations;
- correct the quantified index in the sorted-`d` observation from `i` to `l`.

## Details

The article accepts `vector<int>` input but does not state a value bound. The two implementations currently use `INF = 1e9` and `-INF` as sentinels in an `int` DP array. Valid inputs at or beyond those values can violate the sentinel assumptions; in the binary-search version, a sufficiently large value can also make `upper_bound` return `d.end()` before the code accesses `d[l]`.

This PR changes the DP array to `long long` and uses `±(1LL << 60)`, which strictly contains the full possible `int` input range while leaving the algorithm unchanged.

The same section states `d[l-1] < d[l]` but says it holds "for all i". Since the inequality is indexed by `l`, the quantified variable is corrected to `l`.

## Duplicate check

Verified both issues on the current upstream `main` (`3b975255ac87ab87e513b88b5366749609ecb28c`) and searched open issues/PRs for the sentinel and index wording. PR #1651 changes LIS restoration only and does not overlap these fixes.

English source only; no translation or i18n changes.