### PR TITLE
Improve basic geometry documentation wording

### DIFF
--- a/src/geometry/circle-circle-intersection.md
+++ b/src/geometry/circle-circle-intersection.md
@@ -36,7 +36,7 @@ C &= x_2^2+y_2^2+r_1^2-r_2^2
 
 And this problem can be solved as described in the [corresponding article](circle-line-intersection.md).
 
-The only degenerate case we need to consider separately is when the centers of the circles coincide. In this case $x_2=y_2=0$, and the line equation will be $C = r_1^2-r_2^2 = 0$. If the radii of the circles are the same, there are infinitely many intersection points, if they differ, there are no intersections.
+The only degenerate case we need to consider separately is when the centers of the circles coincide. In this case $x_2=y_2=0$, so $A=B=0$ and the remaining equation is $C=r_1^2-r_2^2=0$. This equation is satisfied exactly when the radii are equal. If they are equal, the circles coincide and there are infinitely many intersection points; otherwise, there are no intersections.
 
 ## Practice Problems
 

--- a/src/geometry/circle-line-intersection.md
+++ b/src/geometry/circle-line-intersection.md
@@ -14,7 +14,7 @@ Instead of solving the system of two equations, we will approach the problem geo
 
 We assume without loss of generality that the circle is centered at the origin. If it's not, we translate it there and correct the $C$ constant in the line equation. So we have a circle centered at $(0,0)$ of radius $r$ and a line with equation $Ax+By+C=0$.
 
-Let's start by find the point on the line which is closest to the origin $(x_0, y_0)$. First, it has to be at a distance
+Let's start by finding the point on the line which is closest to the origin $(x_0, y_0)$. First, it has to be at a distance
 
 $$ d_0 = \frac{|C|}{\sqrt{A^2+B^2}} $$
 
@@ -33,7 +33,7 @@ So, we know that the point $(x_0, y_0)$ is inside the circle. The two points of 
 
 $$ d = \sqrt{r^2 - \frac{C^2}{A^2 + B^2}} $$
 
-Note that the vector $(-B, A)$ is collinear to the line, and thus we can find the points in question by adding and subtracting  vector $(-B,A)$, scaled to the length $d$, to the point $(x_0, y_0)$. 
+Note that the vector $(-B, A)$ is collinear to the line, and thus we can find the points in question by adding and subtracting the vector $(-B,A)$, scaled to the length $d$, to the point $(x_0, y_0)$. 
 
 Finally, the equations of the two points of intersection are:
 
@@ -43,7 +43,7 @@ a_x &= x_0 + B \cdot m, a_y = y_0 - A \cdot m \\
 b_x &= x_0 - B \cdot m, b_y = y_0 + A \cdot m
 \end{align}$$
 
-Had we solved the original system of equations using algebraic methods, we would likely get an answer in a different form with a larger error. The geometric method described here is more graphic and more accurate.
+Had we solved the original system of equations using algebraic methods, we would likely get an answer in a different form with a larger error. The geometric method described here is more intuitive and more accurate.
 
 ## Implementation
 

--- a/src/geometry/length-of-segments-union.md
+++ b/src/geometry/length-of-segments-union.md
@@ -10,7 +10,7 @@ Given $n$ segments on a line, each described by a pair of coordinates $(a_{i1}, 
 We have to find the length of their union.
 
 The following algorithm was proposed by Klee in 1977.
-It works in $O(n\log n)$ and has been proven to be the asymptotically optimal.
+It works in $O(n\log n)$ and has been proven asymptotically optimal.
 
 ## Solution
 
@@ -18,7 +18,7 @@ We store in an array $x$ the endpoints of all the segments sorted by their value
 And additionally we store whether it is a left end or a right end of a segment.
 Now we iterate over the array, keeping a counter $c$ of currently opened segments.
 Whenever the current element is a left end, we increase this counter, and otherwise we decrease it.
-To compute the answer, we take the length between the last two $x$ values $x_i - x_{i-1}$, whenever we come to a new coordinate, and there is currently at least one segment is open.
+To compute the answer, we take the length between the last two $x$ values $x_i - x_{i-1}$ whenever we come to a new coordinate and at least one segment is currently open.
 
 ## Implementation
 

--- a/src/geometry/lines-intersection.md
+++ b/src/geometry/lines-intersection.md
@@ -30,7 +30,7 @@ $$\begin{vmatrix}a_1 & b_1 \cr a_2 & b_2\end{vmatrix} = a_1 b_2 - a_2 b_1 = 0 $$
 
 then either the system has no solutions (the lines are parallel and distinct) or there are infinitely many solutions (the lines overlap).
 If we need to distinguish these two cases, we have to check if coefficients $c$ are proportional with the same ratio as the coefficients $a$ and $b$.
-To do that we only have calculate the following determinants, and if they both equal $0$, the lines overlap:
+To do that we only have to calculate the following determinants, and if they both equal $0$, the lines overlap:
 
 $$\begin{vmatrix}a_1 & c_1 \cr a_2 & c_2\end{vmatrix}, \begin{vmatrix}b_1 & c_1 \cr b_2 & c_2\end{vmatrix} $$
 

--- a/src/geometry/segment-to-line.md
+++ b/src/geometry/segment-to-line.md
@@ -35,8 +35,8 @@ C &= - A P_x - B P_y.
 An important advantage of this method of constructing a straight line is that if the coordinates of the ends were integer, then the coefficients obtained will also be **integer** . In some cases, this allows one to perform geometric operations without resorting to real numbers at all.
 
 However, there is a small drawback: for the same straight line different triples of coefficients can be obtained.
-To avoid this, but do not go away from the integer coefficients, you can apply the following technique, often called **rationing**. Find the [greatest common divisor](../algebra/euclid-algorithm.md) of numbers $| A | , | B | , | C |$ , we divide all three coefficients by it, and then we make the normalization of the sign: if $A <0$ or $A = 0, B <0$ then multiply all three coefficients by $-1$ .
-As a result, we will come to the conclusion that for identical straight lines, identical triples of coefficients will be obtained, which makes it easy to check straight lines for equality.
+To avoid this while retaining integer coefficients, normalize the coefficients as follows. Find the [greatest common divisor](../algebra/euclid-algorithm.md) of numbers $| A | , | B | , | C |$ , divide all three coefficients by it, and then normalize the sign: if $A <0$ or $A = 0, B <0$ then multiply all three coefficients by $-1$ .
+As a result, identical straight lines will produce identical triples of coefficients, which makes it easy to check straight lines for equality.
 
 ### Real case
 
@@ -63,6 +63,6 @@ Consequently, in the three-dimensional and multidimensional cases we must use th
 
 $$p + v t, ~~~ t \in \mathbb{R}.$$
 
-Those. a straight line is all points that can be obtained from a point $p$ adding a vector $v$ with an arbitrary coefficient.
+That is, a straight line is the set of all points that can be obtained from a point $p$ by adding a vector $v$ multiplied by an arbitrary coefficient.
 
 The **construction** of a straight line in a parametric form along the coordinates of the ends of a segment is trivial, we just take one end of the segment for the point $p$, and the vector from the first to the second end — for the vector $v$.


### PR DESCRIPTION
## Summary

Improve wording and clarity in several introductory geometry articles without changing algorithms, formulas, or code:

- replace the misleading `rationing` wording in the segment-to-line integer normalization and fix a broken explanatory sentence;
- fix a missing `to` in the line-intersection article;
- fix grammar and phrasing in the circle-line intersection explanation;
- clarify the degenerate case when two circle centers coincide;
- fix two grammar issues in the segment-union explanation.

## Motivation

These are small documentation issues in closely related basic geometry articles. The circle-circle change also makes the logic explicit: when the centers coincide, `A = B = 0`, and the remaining condition `r_1^2 - r_2^2 = 0` is satisfied exactly when the radii are equal.

Verified the issues on current `main` (`3b975255ac87ab87e513b88b5366749609ecb28c`) and searched open issues/PRs for overlapping geometry wording fixes before opening this PR.