### PR TITLE
Fix variable in Knuth optimization proof

### DIFF
--- a/src/dynamic_programming/knuth-optimization.md
+++ b/src/dynamic_programming/knuth-optimization.md
@@ -111,7 +111,7 @@ assuming the given conditions are satisfied.
     1. $b = c$  
     The inequality reduces to $dp(a, b) + dp(b, d) \leq dp(a, d)$ (This assumes that $dp(i, i) = 0$ for all $i$, which is the case for all problems using this optimization). Let $opt(a,d) = z$. 
 
-        - If $z < j$,  
+        - If $z < b$,  
         Note that
         
             $$
@@ -126,7 +126,7 @@ assuming the given conditions are satisfied.
 
             From the induction hypothesis, $dp(z+1, b) + dp(b, d) \leq dp(z+1, d)$. Also, it is given that $C(a, b) \leq C(a, d)$. Combining these 2 facts with above inequality yields the desired result.
 
-        - If $z \geq j$, the proof of this case is symmetric to the previous case.
+        - If $z \geq b$, the proof of this case is symmetric to the previous case.
 
     2. $b < c$  
     Let $opt(b, c) = z$ and $opt(a, d) = y$. 


### PR DESCRIPTION
## Summary

Fix the case split in the proof of the quadrangle-inequality lemma in `knuth-optimization.md`:

- `z < j` → `z < b`;
- `z >= j` → `z >= b`.

## Why

In this part of the proof the setup is the case `b = c`, followed by `opt(a,d) = z`. The variable `j` is not defined in that setup. The subsequent argument evaluates `dp(a,b)` and uses `dp(z+1,b)`, so the relevant boundary for the two symmetric cases is `b`.

The change only corrects the variable used in those two conditions; it does not alter the proof structure, formulas, or implementation.

Verified against current upstream `main` (`3b975255ac87ab87e513b88b5366749609ecb28c`) and searched existing issues/PRs for an overlapping Knuth proof fix before submitting.