### PR TITLE
Improve point-in-convex-polygon documentation

### DIFF
--- a/src/geometry/point-in-convex-polygon.md
+++ b/src/geometry/point-in-convex-polygon.md
@@ -17,15 +17,15 @@ Now all other points $p_1,\dots,p_n$ of the polygon are ordered by their polar a
 If the point belongs to the polygon, it belongs to some triangle $p_0, p_i, p_{i + 1}$ (maybe more than one if it lies on the boundary of triangles).
 Consider the triangle $p_0, p_i, p_{i + 1}$ such that $p$ belongs to this triangle and $i$ is maximum among all such triangles.
 
-There is one special case. $p$ lies on the segment $(p_0, p_n)$. This case we will check separately.
+There is one special case. $p$ lies on the segment $(p_0, p_1)$. This case we will check separately.
 Otherwise all points $p_j$ with $j \le i$ are counter-clockwise from $p$ with respect to $p_0$, and all other points are not counter-clockwise from $p$.
 This means that we can apply binary search for the point $p_i$, such that $p_i$ is not counter-clockwise from $p$ with respect to $p_0$, and $i$ is maximum among all such points.
-And afterwards we check if the points is actually in the determined triangle.
+And afterwards we check if the point is actually in the determined triangle.
 
 The sign of $(a - c) \times (b - c)$ will tell us, if the point $a$ is clockwise or counter-clockwise from the point $b$ with respect to the point $c$.
 If $(a - c) \times (b - c) > 0$, then the point $a$ is to the right of the vector going from $c$ to $b$, which means clockwise from $b$ with respect to $c$.
 And if $(a - c) \times (b - c) < 0$, then the point is to the left, or counter clockwise.
-And it is exactly on the line between the points $b$ and $c$.
+If it is zero, then the point $a$ lies exactly on the line through the points $b$ and $c$.
 
 Back to the algorithm:
 Consider a query point $p$.
@@ -36,15 +36,15 @@ Then we handle the special case in which $p$ is part of the line $(p_0, p_1)$.
 And then we can binary search the last point from $p_1,\dots p_n$ which is not counter-clockwise from $p$ with respect to $p_0$.
 For a single point $p_i$ this condition can be checked by checking that $(p_i - p_0)\times(p - p_0) \le 0$. After we found such a point $p_i$, we must test if $p$ lies inside the triangle $p_0, p_i, p_{i + 1}$.
 To test if it belongs to the triangle, we may simply check that $|(p_i - p_0)\times(p_{i + 1} - p_0)| = |(p_0 - p)\times(p_i - p)| + |(p_i - p)\times(p_{i + 1} - p)| + |(p_{i + 1} - p)\times(p_0 - p)|$.
-This checks if the area of the triangle $p_0, p_i, p_{i+1}$ has to exact same size as the sum of the sizes of the triangle $p_0, p_i, p$, the triangle $p_0, p, p_{i+1}$ and the triangle $p_i, p_{i+1}, p$.
-If $p$ is outside, then the sum of those three triangle will be bigger than the size of the triangle.
+This checks if the area of the triangle $p_0, p_i, p_{i+1}$ has exactly the same size as the sum of the sizes of the triangle $p_0, p_i, p$, the triangle $p_0, p, p_{i+1}$ and the triangle $p_i, p_{i+1}, p$.
+If $p$ is outside, then the sum of those three triangles will be bigger than the size of the triangle.
 If it is inside, then it will be equal.
 
 ## Implementation
 
-The function `prepare` will make sure that the lexicographical smallest point (smallest x value, and in ties smallest y value) will be $p_0$, and computes the vectors $p_i - p_0$.
+The function `prepare` will make sure that the lexicographically smallest point (smallest x value, and in ties smallest y value) will be $p_0$, and computes the vectors $p_i - p_0$.
 Afterwards the function `pointInConvexPolygon` computes the result of a query.
-We additionally remember the point $p_0$ and translate all queried points with it in order compute the correct distance, as vectors don't have an initial point.
+We additionally remember the point $p_0$ and translate all queried points relative to it in order to compute the correct distance, as vectors don't have an initial point.
 By translating the query points we can assume that all vectors start at the origin $(0, 0)$, and simplify the computations for distances and lengths.
 
 ```{.cpp file=points_in_convex_polygon}


### PR DESCRIPTION
## Summary

Improve wording and fix an inconsistent special-case description in `src/geometry/point-in-convex-polygon.md`.

The main correctness-related change is:

- the early algorithm description says the separately handled special case is the segment `(p_0, p_n)`;
- the later algorithm description and the implementation both special-case `(p_0, p_1)`;
- update the early description to `(p_0, p_1)` so the article is internally consistent.

The same small documentation patch also fixes nearby grammar/wording issues (`the points is`, `has to exact same size`, `three triangle`, `lexicographical`, and `in order compute`) and clarifies the zero-cross-product sentence.

No code, formulas, or algorithm behavior are changed.

Verified against current upstream `main` (`3b975255ac87ab87e513b88b5366749609ecb28c`) and searched open issues/PRs for an overlapping point-in-convex-polygon documentation fix before submitting.