### PR TITLE
Fix Pick theorem and Minkowski distance wording

### DIFF
--- a/src/geometry/minkowski.md
+++ b/src/geometry/minkowski.md
@@ -47,8 +47,8 @@ Here is a nice visualization, which may help you understand what is going on.
 
 ## Distance between two polygons
 One of the most common applications of Minkowski sum is computing the distance between two convex polygons (or simply checking whether they intersect).
-The distance between two convex polygons $P$ and $Q$ is defined as $\min\limits_{a \in P, b \in Q} ||a - b||$. One can note that
-the distance is always attained between two vertices or a vertex and an edge, so we can easily find the distance in $O(|P||Q|)$. However,
+The distance between two convex polygons $P$ and $Q$ is defined as $\min\limits_{a \in P, b \in Q} ||a - b||$. If the polygons intersect, this distance is $0$.
+Otherwise, the minimum distance is attained between two vertices or between a vertex and an edge, so a straightforward pairwise check takes $O(|P||Q|)$ time. However,
 with clever usage of Minkowski sum we can reduce the complexity to $O(|P| + |Q|)$.
 
 If we reflect $Q$ through the point $(0, 0)$ obtaining polygon $-Q$, the problem boils down to finding the smallest distance between a point in

--- a/src/geometry/picks-theorem.md
+++ b/src/geometry/picks-theorem.md
@@ -6,7 +6,7 @@ e_maxx_link: pick_grid_theorem
 
 # Pick's Theorem
 
-A polygon without self-intersections is called lattice if all its vertices have integer coordinates in some 2D grid. Pick's theorem provides a way to compute the area of this polygon through the number of vertices that are lying on the boundary and the number of vertices that lie strictly inside the polygon.
+A polygon without self-intersections is called lattice if all its vertices have integer coordinates in some 2D grid. Pick's theorem provides a way to compute the area of this polygon through the number of lattice points that are lying on the boundary and the number of lattice points that lie strictly inside the polygon.
 
 ## Formula
 
@@ -28,13 +28,13 @@ The proof is carried out in many stages: from simple polygons to arbitrary ones:
 
 - A single square: $S=1, I=0, B=4$, which satisfies the formula.
 
-- An arbitrary non-degenerate rectangle with sides parallel to coordinate axes: Assume $a$ and $b$ be the length of the sides of rectangle. Then, $S=ab, I=(a-1)(b-1), B=2(a+b)$. On substituting, we see that formula is true.
+- An arbitrary non-degenerate rectangle with sides parallel to coordinate axes: Let $a$ and $b$ be the lengths of the sides of the rectangle. Then, $S=ab, I=(a-1)(b-1), B=2(a+b)$. On substituting, we see that the formula is true.
 
-- A right angle with legs parallel to the axes: To prove this, note that any such triangle can be obtained by cutting off a rectangle by a diagonal. Denoting the number of integral points lying on diagonal by $c$, it can be shown that Pick's formula holds for this triangle regardless of $c$.
+- A right triangle with legs parallel to the axes: To prove this, note that any such triangle can be obtained by cutting a rectangle by a diagonal. Denoting the number of integral points lying on the diagonal by $c$, it can be shown that Pick's formula holds for this triangle regardless of $c$.
 
-- An arbitrary triangle: Note that any such triangle can be turned into a rectangle by attaching it to sides of right-angled triangles with legs parallel to the axes (you will not need more than 3 such triangles). From here, we can get correct formula for any triangle.
+- An arbitrary triangle: Note that any such triangle can be turned into a rectangle by attaching it to sides of right-angled triangles with legs parallel to the axes (you will not need more than 3 such triangles). From here, we can get the correct formula for any triangle.
 
-- An arbitrary polygon: To prove this, triangulate it, ie, divide into triangles with integral coordinates. Further, it is possible to prove that Pick's theorem retains its validity when a polygon is added to a triangle. Thus, we have proven Pick's formula for arbitrary polygon.
+- An arbitrary polygon: To prove this, triangulate it, i.e., divide it into triangles with integral coordinates. Further, it is possible to prove that Pick's theorem retains its validity when a polygon is added to a triangle. Thus, we have proven Pick's formula for an arbitrary polygon.
 
 ## Generalization to higher dimensions
 
@@ -47,9 +47,9 @@ B=(1,0,0),
 C=(0,1,0),
 D=(1,1,k),$$
 
-where $k$ can be any natural number. Then for any $k$, the tetrahedron $ABCD$ does not contain integer point inside it and has only $4$ points on its borders, $A, B, C, D$. Thus, the volume and surface area may vary in spite of unchanged number of points within and on boundary. Therefore, Pick's theorem doesn't allow generalizations.
+where $k$ can be any natural number. Then for any $k$, the tetrahedron $ABCD$ does not contain an integer point inside it and has only $4$ points on its boundary, $A, B, C, D$. Thus, the volume and surface area may vary in spite of an unchanged number of points within and on the boundary. Therefore, Pick's theorem doesn't allow this kind of direct generalization.
 
-However, higher dimensions still has a generalization using **Ehrhart polynomials** but they are quite complex and depends not only on points inside but also on the boundary of polytype.
+There is, however, a higher-dimensional generalization using **Ehrhart polynomials**, but it is more complex and depends not only on points inside but also on the boundary of the polytope.
 
 ## Extra Resources
 A few simple examples and a simple proof of Pick's theorem can be found [here](http://www.geometer.org/mathcircles/pick.pdf).

--- a/src/geometry/picks-theorem.md
+++ b/src/geometry/picks-theorem.md
@@ -12,7 +12,7 @@ A polygon without self-intersections is called lattice if all its vertices have 
 
 Given a certain lattice polygon with non-zero area.
 
-We denote its area by $S$, the number of points with integer coordinates lying strictly inside the polygon by $I$ and the number of points lying on polygon sides by $B$.
+We denote its area by $S$, the number of points with integer coordinates lying strictly inside the polygon by $I$ and the number of lattice points lying on polygon sides by $B$.
 
 Then, the **Pick's formula** states:
 
@@ -26,7 +26,7 @@ This formula was discovered and proven by Austrian mathematician Georg Alexander
 
 The proof is carried out in many stages: from simple polygons to arbitrary ones:
 
-- A single square: $S=1, I=0, B=4$, which satisfies the formula.
+- A unit square: $S=1, I=0, B=4$, which satisfies the formula.
 
 - An arbitrary non-degenerate rectangle with sides parallel to coordinate axes: Let $a$ and $b$ be the lengths of the sides of the rectangle. Then, $S=ab, I=(a-1)(b-1), B=2(a+b)$. On substituting, we see that the formula is true.
 
@@ -34,7 +34,7 @@ The proof is carried out in many stages: from simple polygons to arbitrary ones:
 
 - An arbitrary triangle: Note that any such triangle can be turned into a rectangle by attaching it to sides of right-angled triangles with legs parallel to the axes (you will not need more than 3 such triangles). From here, we can get the correct formula for any triangle.
 
-- An arbitrary polygon: To prove this, triangulate it, i.e., divide it into triangles with integral coordinates. Further, it is possible to prove that Pick's theorem retains its validity when a polygon is added to a triangle. Thus, we have proven Pick's formula for an arbitrary polygon.
+- An arbitrary polygon: To prove this, triangulate it, i.e., divide it into triangles whose vertices have integer coordinates. Further, it is possible to prove that Pick's theorem retains its validity when a triangle is attached to a polygon along a shared edge. Thus, we have proven Pick's formula for an arbitrary polygon.
 
 ## Generalization to higher dimensions
 


### PR DESCRIPTION
## Summary

Clarify two geometry articles where the current wording is technically misleading.

### `src/geometry/picks-theorem.md`
- replace `vertices` with `lattice points` in the introductory description of Pick's theorem;
- make the definition of `B` explicitly count lattice points on the boundary;
- clarify that the base case is a **unit square**, matching `S=1, I=0, B=4`;
- fix `A right angle with legs...` to `A right triangle with legs...` in the proof outline;
- clarify that triangulation produces triangles whose **vertices** have integer coordinates and that the induction step attaches a triangle along a shared edge;
- clean up nearby grammar/wording, including `polytype` → `polytope`, without changing formulas or mathematical content.

### `src/geometry/minkowski.md`
- make the intersection case explicit when discussing distance between convex polygons: intersecting polygons have distance `0`, while the vertex/edge characterization is used for the disjoint case.

No code, formulas, links, or algorithm behavior are changed.

Verified against current upstream `main` (`3b975255ac87ab87e513b88b5366749609ecb28c`). Searched open issues and PRs for the Pick-theorem wording and Minkowski distance/intersection wording before submitting and found no overlapping correction.