### PR TITLE
Fix Fibonacci divisibility and divisor multiset wording

### DIFF
--- a/src/algebra/divisors.md
+++ b/src/algebra/divisors.md
@@ -9,13 +9,13 @@ In this article we discuss how to compute the number of divisors $d(n)$ and the 
 
 ## Number of divisors
 
-It should be obvious that the prime factorization of a divisor $d$ has to be a subset of the prime factorization of $n$, e.g. $6 = 2 \cdot 3$ is a divisor of $60 = 2^2 \cdot 3 \cdot 5$.
-So we only need to find all different subsets of the prime factorization of $n$.
+The prime factors of a divisor $d$, including their multiplicities, have to form a submultiset of the prime factors of $n$; e.g. $6 = 2 \cdot 3$ is a divisor of $60 = 2^2 \cdot 3 \cdot 5$.
+So we only need to count all different submultisets of the prime factorization of $n$.
 
-Usually the number of subsets is $2^x$ for a set with $x$ elements.
-However this is no longer true, if there are repeated elements in the set. In our case some prime factors may appear multiple times in the prime factorization of $n$.
+A set with $x$ distinct elements has $2^x$ subsets.
+In our case, however, some prime factors may appear multiple times in the prime factorization of $n$, so we are choosing from a multiset rather than a set.
 
-If a prime factor $p$ appears $e$ times in the prime factorization of $n$, then we can use the factor $p$ up to $e$ times in the subset.
+If a prime factor $p$ appears $e$ times in the prime factorization of $n$, then we can use the factor $p$ up to $e$ times in the submultiset.
 Which means we have $e+1$ choices.
 
 Therefore if the prime factorization of $n$ is $p_1^{e_1} \cdot p_2^{e_2} \cdots p_k^{e_k}$, where $p_i$ are distinct prime numbers, then the number of divisors is:
@@ -71,7 +71,7 @@ We can use the same argument of the previous section.
 $$1 + p_1 + p_1^2 + \dots + p_1^{e_1} = \frac{p_1^{e_1 + 1} - 1}{p_1 - 1}$$
 
 * If there are two distinct prime divisors $n = p_1^{e_1} \cdot p_2^{e_2}$, then we can make the same table as before.
-  The only difference is that now we now want to compute the sum instead of counting the elements.
+  The only difference is that now we want to compute the sum instead of counting the elements.
   It is easy to see, that the sum of each combination can be expressed as:
 
 $$\left(1 + p_1 + p_1^2 + \dots + p_1^{e_1}\right) \cdot \left(1 + p_2 + p_2^2 + \dots + p_2^{e_2}\right)$$

--- a/src/algebra/fibonacci-numbers.md
+++ b/src/algebra/fibonacci-numbers.md
@@ -34,7 +34,7 @@ $$F_{2n} = F_n (F_{n+1} + F_{n-1})$$
 
 * From this we can prove by induction that for any positive integer $k$,  $F_{nk}$ is multiple of $F_n$.
 
-* The inverse is also true: if $F_m$ is multiple of $F_n$, then $m$ is multiple of $n$.
+* For $n \ge 3$, the inverse is also true: if $F_m$ is multiple of $F_n$, then $m$ is multiple of $n$.
 
 * GCD identity:
   
@@ -99,7 +99,7 @@ As these two formulas would require very high accuracy when working with fractio
 
 The $n$-th Fibonacci number can be easily found in $O(n)$ by computing the numbers one by one up to $n$. However, there are also faster ways, as we will see.
 
-We can start from an iterative approach, to take advantage of the use of the formula $F_n = F_{n-1} + F_{n-2}$, therefore, we will simply precalculate those values in an array. Taking into account the base cases for $F_0$ and $F_1$.
+We can start from an iterative approach using the formula $F_n = F_{n-1} + F_{n-2}$. The implementation only needs to keep the two most recent values, starting from the base cases $F_0$ and $F_1$.
 
 ```{.cpp file=fibonacci_linear}
 int fib(int n) {
@@ -114,7 +114,7 @@ int fib(int n) {
 }
 ```
 
-In this way, we obtain a linear solution, $O(n)$ time, saving all the values prior to $n$ in the sequence.
+In this way, we obtain a linear solution with $O(n)$ time and $O(1)$ additional memory.
 
 ### Matrix form
 


### PR DESCRIPTION
## Summary

Fix a few small correctness/wording issues found while reviewing the number-theory documentation.

### `src/algebra/fibonacci-numbers.md`

- Restrict the converse divisibility statement to `n >= 3`. As currently written, the statement is false for `n = 2` because `F_2 = 1` divides every Fibonacci number; for example `F_2 | F_3` but `2` does not divide `3`.
- Make the linear-time explanation match the implementation. The code keeps only the two most recent Fibonacci values, so it uses `O(1)` additional memory rather than precomputing/storing all previous values in an array.

### `src/algebra/divisors.md`

- Replace the contradictory wording about a set containing repeated prime factors with the mathematically precise multiset/submultiset terminology.
- Remove the duplicated `now` in the sum-of-divisors paragraph.

No code, formulas, links, or algorithm behavior are changed.

## Verification

- Checked against current upstream `main` at `3b975255ac87ab87e513b88b5366749609ecb28c`.
- Read `CONTRIBUTING.md`.
- Searched open issues and pull requests for the distinctive Fibonacci divisibility/memory wording and divisor set/multiset wording; no overlapping correction was found. Existing Fibonacci issues #1657 and #976 concern different points.