### PR TITLE
Fix bit manipulation edge case and Gray code disk typo

### DIFF
--- a/src/algebra/bit-manipulation.md
+++ b/src/algebra/bit-manipulation.md
@@ -51,7 +51,7 @@ All those introduced operators are instant (same speed as an addition) on a CPU 
 -   $|$ : The bitwise inclusive OR operator compares each bit of its first operand with the corresponding bit of its second operand.
     If one of the two bits is 1, the corresponding result bit is set to 1. Otherwise, the corresponding result bit is set to 0.
 
--   $\wedge$ : The bitwise exclusive OR (XOR) operator compares each bit of its first operand with the corresponding bit of its second operand.
+-   $\oplus$ : The bitwise exclusive OR (XOR) operator compares each bit of its first operand with the corresponding bit of its second operand.
     If one bit is 0 and the other bit is 1, the corresponding result bit is set to 1. Otherwise, the corresponding result bit is set to 0.
 
 -   $\sim$ : The bitwise complement (NOT) operator flips each bit of a number, if a bit is set the operator will clear it, if it is cleared the operator sets it.
@@ -111,7 +111,7 @@ Using bitwise shifts and some basic bitwise operations we can easily set, flip o
 $1 \ll x$ is a number with only the $x$-th bit set, while $\sim(1 \ll x)$ is a number with all bits set except the $x$-th bit.
 
 - $n ~|~ (1 \ll x)$ sets the $x$-th bit in the number $n$
-- $n ~\wedge~ (1 \ll x)$ flips the $x$-th bit in the number $n$
+- $n ~\oplus~ (1 \ll x)$ flips the $x$-th bit in the number $n$
 - $n ~\&~ \sim(1 \ll x)$ clears the $x$-th bit in the number $n$
 
 ### Check if a bit is set
@@ -206,7 +206,7 @@ We can see that the all the columns except the leftmost have $4$ (i.e. $2^2$) se
 
 With the new knowledge in hand we can come up with the following algorithm:
 
-- Find the highest power of $2$ that is lesser than or equal to the given number. Let this number be $x$.
+- Find the largest exponent $x$ such that $2^x$ is lesser than or equal to the given number.
 - Calculate the number of set bits from $1$ to $2^x - 1$ by using the formula $x \cdot 2^{x-1}$.
 - Count the no. of set bits in the most significant bit from $2^x$ to $n$ and add it.
 - Subtract $2^x$ from $n$ and repeat the above steps using the new $n$.
@@ -216,7 +216,8 @@ int countSetBits(int n) {
         int count = 0;
         while (n > 0) {
             int x = std::bit_width(n) - 1;
-            count += x << (x - 1);
+            if (x > 0)
+                count += x << (x - 1);
             n -= 1 << x;
             count += n + 1;
         }

--- a/src/algebra/gray-code.md
+++ b/src/algebra/gray-code.md
@@ -58,7 +58,7 @@ Gray codes have some useful applications, sometimes quite unexpected:
 *   Gray code can be used to solve the Towers of Hanoi problem.
     Let $n$ denote number of disks. Start with Gray code of length $n$ which
     consists of all zeroes ($G(0)$) and move between consecutive Gray codes (from $G(i)$ to $G(i+1)$).
-    Let $i$-th bit of current Gray code represent $n$-th disk 
+    Let $i$-th bit of current Gray code represent $i$-th disk 
     (the least significant bit corresponds to the smallest disk and the most significant bit to the biggest disk). 
     Since exactly one bit changes on each step, we can treat changing $i$-th bit as moving $i$-th disk.
     Notice that there is exactly one move option for each disk (except the smallest one) on each step (except start and finish positions).

--- a/src/algebra/gray-code.md
+++ b/src/algebra/gray-code.md
@@ -64,7 +64,7 @@ Gray codes have some useful applications, sometimes quite unexpected:
     Notice that there is exactly one move option for each disk (except the smallest one) on each step (except start and finish positions).
     There are always two move options for the smallest disk but there is a strategy which will always lead to answer:
     if $n$ is odd then sequence of the smallest disk moves looks like $f \to t \to r \to f \to t \to r \to ...$
-    where $f$ is the initial rod, $t$ is the terminal rod and $r$ is the remaining rod), and 
+    where $f$ is the initial rod, $t$ is the terminal rod and $r$ is the remaining rod, and 
     if $n$ is even: $f \to r \to t \to f \to r \to t \to ...$.
 
 *   Gray codes are also used in genetic algorithms theory.


### PR DESCRIPTION
## Summary

Fix a few small correctness/presentation issues in the bit-manipulation and Gray-code documentation.

### `src/algebra/bit-manipulation.md`

- Use `\oplus` instead of `\wedge` for XOR. `\wedge` conventionally denotes logical/bitwise conjunction, while the article is describing exclusive OR and the C++ examples use `^`.
- Clarify that `x` in the set-bit counting algorithm is the largest **exponent** such that `2^x <= n`, matching the formulas and implementation.
- Guard the `x << (x - 1)` contribution when `x == 0`. Without the guard, `countSetBits(1)` attempts a shift with a negative shift count.

### `src/algebra/gray-code.md`

- Fix the Towers of Hanoi mapping from “the `i`-th bit represents the `n`-th disk” to the `i`-th disk, matching the very next sentence and the least/most-significant-bit explanation.
- Remove the unmatched closing parenthesis after the description of the remaining rod.

## Verification

- Checked against upstream `main` at `3b975255ac87ab87e513b88b5366749609ecb28c` before creating the branch.
- Searched open issues and pull requests for the distinctive `countSetBits`/`bit_width`, Gray-code disk-index, and XOR-notation issues; no overlapping correction was found.
- Current branch: 3 commits, 2 English source files, +7/-6.
- No translation/i18n changes are included.