### PR TITLE
Fix Newton zero case and Simpson integration formulas

### DIFF
--- a/src/num_methods/roots_newton.md
+++ b/src/num_methods/roots_newton.md
@@ -66,10 +66,12 @@ double sqrt_newton(double n) {
 }
 ```
 
-Another common variant of the problem is when we need to calculate the integer root (for the given $n$ find the largest $x$ such that $x^2 \le n$). Here it is necessary to slightly change the termination condition of the algorithm, since it may happen that $x$ will start to "jump" near the answer. Therefore, we add a condition that if the value $x$ has decreased in the previous step, and it tries to increase at the current step, then the algorithm must be stopped.
+Another common variant of the problem is when we need to calculate the integer root (for the given non-negative $n$ find the largest $x$ such that $x^2 \le n$). Here it is necessary to slightly change the termination condition of the algorithm, since it may happen that $x$ will start to "jump" near the answer. Therefore, we add a condition that if the value $x$ has decreased in the previous step, and it tries to increase at the current step, then the algorithm must be stopped.
 
 ```cpp
 int isqrt_newton(int n) {
+	if (n == 0)
+		return 0;
 	int x = 1;
 	bool decreased = false;
 	for (;;) {
@@ -87,6 +89,8 @@ Finally, we are given the third variant - for the case of bignum arithmetic. Sin
 
 ```java
 public static BigInteger isqrtNewton(BigInteger n) {
+	if (n.signum() == 0)
+		return BigInteger.ZERO;
 	BigInteger a = BigInteger.ONE.shiftLeft(n.bitLength() / 2);
 	boolean p_dec = false;
 	for (;;) {

--- a/src/num_methods/roots_newton.md
+++ b/src/num_methods/roots_newton.md
@@ -75,7 +75,7 @@ int isqrt_newton(int n) {
 	int x = 1;
 	bool decreased = false;
 	for (;;) {
-		int nx = (x + n / x) >> 1;
+		int nx = (x + 1LL * n / x) >> 1;
 		if (x == nx || nx > x && decreased)
 			break;
 		decreased = nx < x;

--- a/src/num_methods/simpson-integration.md
+++ b/src/num_methods/simpson-integration.md
@@ -22,30 +22,30 @@ $$h = \frac {b-a} {2n}.$$
 
 Now we calculate the integral separately on each of the segments $[x_ {2i-2}, x_ {2i}]$, $i = 1 \ldots n$, and then add all the values.
 
-So, suppose we consider the next segment $[x_ {2i-2}, x_ {2i}],  i = 1 \ldots n$. Replace the function $f(x)$ on it with a parabola $P(x)$ passing through 3 points $(x_ {2i-2}, x_ {2i-1}, x_ {2i})$. Such a parabola always exists and is unique; it can be found analytically.
+So, suppose we consider the next segment $[x_ {2i-2}, x_ {2i}],  i = 1 \ldots n$. Replace the function $f(x)$ on it with a parabola $P(x)$ passing through the three graph points $(x_{2i-2}, f(x_{2i-2}))$, $(x_{2i-1}, f(x_{2i-1}))$, and $(x_{2i}, f(x_{2i}))$. Such a parabola always exists and is unique; it can be found analytically.
 For instance we could construct it using the Lagrange polynomial interpolation.
 The only remaining thing left to do is to integrate this polynomial.
 If you do this for a general function $f$, you receive a remarkably simple expression:
 
-$$\int_{x_ {2i-2}} ^ {x_ {2i}} f (x) ~dx \approx \int_{x_ {2i-2}} ^ {x_ {2i}} P (x) ~dx = \left(f(x_{2i-2}) + 4f(x_{2i-1})+(f(x_{2i})\right)\frac {h} {3} $$
+$$\int_{x_ {2i-2}} ^ {x_ {2i}} f (x) ~dx \approx \int_{x_ {2i-2}} ^ {x_ {2i}} P (x) ~dx = \left(f(x_{2i-2}) + 4f(x_{2i-1}) + f(x_{2i})\right)\frac {h} {3} $$
 
 Adding these values over all segments, we obtain the final **Simpson's formula**:
 
-$$\int_a ^ b f (x) dx \approx \left(f (x_0) + 4 f (x_1) + 2 f (x_2) + 4f(x_3) + 2 f(x_4) + \ldots + 4 f(x_{2N-1}) + f(x_{2N}) \right)\frac {h} {3} $$
+$$\int_a ^ b f (x) dx \approx \left(f (x_0) + 4 f (x_1) + 2 f (x_2) + 4f(x_3) + 2 f(x_4) + \ldots + 4 f(x_{2n-1}) + f(x_{2n}) \right)\frac {h} {3} $$
 
 ## Error
 
-The error in approximating an integral by Simpson's formula is
+For one Simpson panel spanning an interval $[a,b]$, the error is
 
 $$ -\tfrac{1}{90} \left(\tfrac{b-a}{2}\right)^5 f^{(4)}(\xi)$$
 
 where $\xi$ is some number between $a$ and $b$.
 
-The error is asymptotically proportional to $(b-a)^5$. However, the above derivations suggest an error proportional to $(b-a)^4$. Simpson's rule gains an extra order because the points at which the integrand is evaluated are distributed symmetrically in the interval $[a, b]$.
+Thus the single-panel error is fifth-order in the panel width. In the composite rule above, the interval is split into panels of width $2h$. Assuming the fourth derivative remains bounded, summing the panel errors gives a global error of order $O((b-a)h^4)$. Simpson's rule gains an extra order compared with a naive interpolation-error estimate because the points at which the integrand is evaluated are distributed symmetrically in each panel.
 
 ## Implementation
 
-Here, $f(x)$ is some user-defined function.
+Here, $f(x)$ is some user-defined function. The number of steps $N$ must be even.
 
 ```cpp
 const int N = 1000 * 1000; // number of steps (already multiplied by 2)


### PR DESCRIPTION
## Summary

Fix small correctness and presentation issues in two numerical-methods articles.

### `src/num_methods/roots_newton.md`

- State that the integer square-root variant takes a non-negative input.
- Handle `n == 0` before the Newton iteration in the C++ implementation. Without the guard, the iteration reaches `x = 0` and then divides by zero on the next step.
- Evaluate the C++ Newton numerator in 64-bit arithmetic. With plain `int`, the first `x + n / x` can signed-overflow for large inputs near `INT_MAX` before the division by two.
- Add the corresponding zero guard to the Java `BigInteger` implementation, which otherwise similarly reaches division by zero for zero input.

### `src/num_methods/simpson-integration.md`

- Describe the interpolation parabola using the three graph points `(x, f(x))`, rather than only listing x-coordinates.
- Remove the extra parenthesis in the one-panel Simpson formula.
- Use the previously defined lowercase `n` consistently in the composite formula instead of switching to `N`.
- Clarify that the displayed fifth-order error formula is for one Simpson panel, while the composite rule has global error of order `O((b-a) h^4)` under the usual bounded-fourth-derivative assumption.
- State explicitly that the implementation requires an even number of steps.

## Verification

- Branch was created directly from upstream `main` at `3b975255ac87ab87e513b88b5366749609ecb28c`.
- Searched open issues and pull requests for the Newton zero-input/overflow failures and Simpson formula/error wording; no overlapping correction was found.
- The branch contains 3 commits and only the two English source files above; no translation/i18n changes are included.