### PR TITLE
docs: clarify Fenwick tree limitation in RMQ

### DIFF
--- a/src/sequences/rmq.md
+++ b/src/sequences/rmq.md
@@ -24,7 +24,7 @@ First the approaches that allow modifications to the array between answering que
 - [Segment tree](../data_structures/segment_tree.md) - answers each query in $O(\log N)$, preprocessing done in $O(N)$.
   Pros: good time complexity. Cons: larger amount of code compared to the other data structures.
 - [Fenwick tree](../data_structures/fenwick.md) - answers each query in $O(\log N)$, preprocessing done in $O(N \log N)$.
-  Pros: the shortest code, good time complexity. Cons: Fenwick tree can only be used for queries with $L = 1$, so it is not applicable to many problems.
+  Pros: the shortest code, good time complexity. Cons: the standard Fenwick tree for RMQ only supports prefix queries ($L = 1$).
 
 And here are the approaches that only work on static arrays, i.e. it is not possible to change a value in the array without recomputing the complete data structure.
 


### PR DESCRIPTION
## Summary

Fixes #1646.

The RMQ article stated that "Fenwick tree can only be used for queries with L=1", which is imprecise because the Fenwick tree article documents a specialized RMQ variant (citing "Efficient Range Minimum Queries using Binary Indexed Trees") that supports arbitrary range queries. The limitation applies only to the standard/simple Fenwick tree implementation for RMQ.

## Changes

- `src/sequences/rmq.md`: Refined the Fenwick tree "Cons" bullet to specify the limitation applies to the *standard* Fenwick tree for RMQ, not all Fenwick variants.

**Before:**
> Cons: Fenwick tree can only be used for queries with $L = 1$, so it is not applicable to many problems.

**After:**
> Cons: the standard Fenwick tree for RMQ only supports prefix queries ($L = 1$).

## Validation

- Markdown renders correctly (verified via `mkdocs` config load and Markdown conversion)
- Change is minimal: 1 file, 1 line changed
- Consistent with repository's documentation fix style (cf. #1692, #1678)

## Related

- Issue: #1646
- Referenced article: `src/data_structures/fenwick.md` (section "Finding minimum of [0, r]")