### PR TITLE
docs: add Dinic dry run example

### DIFF
--- a/src/graph/dinic.md
+++ b/src/graph/dinic.md
@@ -49,6 +49,98 @@ In order to find the blocking flow on each iteration, we may simply try pushing 
 
 A single DFS run takes $O(k+V)$ time, where $k$ is the number of pointer advances on this run. Summed up over all runs, number of pointer advances can not exceed $E$. On the other hand, total number of runs won't exceed $E$, as every run saturates at least one edge. In this way, total running time of finding a blocking flow is $O(VE)$.
 
+## Example
+
+To illustrate how Dinic's algorithm works, we walk through a complete execution on a small network.
+
+### Initial network
+
+The network has four vertices: source $s$, intermediate vertices $A$ and $B$, and sink $t$. The directed edges and their capacities are:
+
+| Edge | Capacity |
+|------|----------|
+| $s \to A$ | 3 |
+| $s \to B$ | 2 |
+| $A \to B$ | 1 |
+| $A \to t$ | 2 |
+| $B \to t$ | 3 |
+
+All initial flows are zero.
+
+<div style="text-align: center;">
+  <img src="dinic_initial.svg" alt="Initial residual network for Dinic example">
+</div>
+
+### First phase
+
+**BFS — level construction.**  
+We run BFS from $s$ in the residual network (all edges have positive residual capacity initially). The shortest unweighted distances are:
+
+| Vertex | $s$ | $A$ | $B$ | $t$ |
+|--------|-----|-----|-----|-----|
+| $level$ | 0 | 1 | 1 | 2 |
+
+**Level graph.**  
+An edge $(u,v)$ belongs to the level graph iff $level[u] + 1 = level[v]$.  
+Edges in the level graph: $s \to A$, $s \to B$, $A \to t$, $B \to t$.  
+The edge $A \to B$ is **excluded** because $level[A] = 1$ and $level[B] = 1$, so $1 + 1 \ne 1$.
+
+<div style="text-align: center;">
+  <img src="dinic_phase1_levels.svg" alt="Phase 1 level graph with levels shown">
+</div>
+
+**Blocking flow (DFS).**  
+We repeatedly push flow from $s$ to $t$ along paths in the level graph:
+
+1. Path $s \to A \to t$: bottleneck = $\min(3, 2) = 2$. Push 2 units.  
+   $s \to A$ becomes $2/3$, $A \to t$ becomes $2/2$ (saturated).
+2. Path $s \to B \to t$: bottleneck = $\min(2, 3) = 2$. Push 2 units.  
+   $s \to B$ becomes $2/2$ (saturated), $B \to t$ becomes $2/3$.
+
+Total flow after phase 1: $2 + 2 = 4$.
+
+The level graph now has no $s \to t$ path (both $A \to t$ and $B \to t$ are saturated, and $A \to B$ is not in the level graph). Hence this is a blocking flow.
+
+<div style="text-align: center;">
+  <img src="dinic_phase1_blocking.svg" alt="Network after phase 1 blocking flow">
+</div>
+
+### Second phase
+
+**Residual network after phase 1.**  
+Forward residual capacities:  
+$s \to A$: 1, $A \to B$: 1, $B \to t$: 1.  
+Edges $s \to B$ and $A \to t$ have zero forward residual capacity (saturated).
+
+**BFS — new level construction.**  
+Running BFS again on the residual network gives:
+
+| Vertex | $s$ | $A$ | $B$ | $t$ |
+|--------|-----|-----|-----|-----|
+| $level$ | 0 | 1 | 2 | 3 |
+
+Now $A$ and $B$ are on different levels, so $A \to B$ enters the level graph. The new level-graph path is $s \to A \to B \to t$.
+
+<div style="text-align: center;">
+  <img src="dinic_phase2_final.svg" alt="Phase 2 level graph and final maximum flow">
+</div>
+
+**Blocking flow (DFS).**  
+Path $s \to A \to B \to t$: bottleneck = $\min(1, 1, 1) = 1$. Push 1 unit.
+
+Final edge flows:
+- $s \to A = 3/3$ (saturated)
+- $s \to B = 2/2$ (saturated)
+- $A \to B = 1/1$ (saturated)
+- $A \to t = 2/2$ (saturated)
+- $B \to t = 3/3$ (saturated)
+
+Total flow: $4 + 1 = 5$.
+
+### Result
+
+The flow value is 5. All edges leaving $s$ are saturated, so no larger flow is possible. The residual network contains no path from $s$ to $t$, and Dinic's algorithm terminates. The maximum flow equals 5.
+
 ## Complexity
 
 There are less than $V$ phases, so the total complexity is $O(V^2E)$.

--- a/src/graph/dinic_initial.svg
+++ b/src/graph/dinic_initial.svg
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg width="500" height="200" viewBox="0 0 500 200" xmlns="http://www.w3.org/2000/svg">
-  <!-- Styles -->
   <defs>
     <marker id="arrowhead" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto">
       <polygon points="0 0, 10 3.5, 0 7" fill="#333"/>
@@ -10,7 +9,6 @@
       .vertex-label { font-family: sans-serif; font-size: 16px; font-weight: bold; fill: #333; text-anchor: middle; dominant-baseline: middle; }
       .edge { fill: none; stroke: #333; stroke-width: 2; marker-end: url(#arrowhead); }
       .edge-label { font-family: sans-serif; font-size: 13px; fill: #333; text-anchor: middle; dominant-baseline: middle; }
-      .edge-label-bg { fill: white; fill-opacity: 0.9; }
     </style>
   </defs>
   

--- a/src/graph/dinic_initial.svg
+++ b/src/graph/dinic_initial.svg
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="500" height="200" viewBox="0 0 500 200" xmlns="http://www.w3.org/2000/svg">
+  <!-- Styles -->
+  <defs>
+    <marker id="arrowhead" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto">
+      <polygon points="0 0, 10 3.5, 0 7" fill="#333"/>
+    </marker>
+    <style>
+      .vertex { fill: #e0e0e0; stroke: #333; stroke-width: 2; }
+      .vertex-label { font-family: sans-serif; font-size: 16px; font-weight: bold; fill: #333; text-anchor: middle; dominant-baseline: middle; }
+      .edge { fill: none; stroke: #333; stroke-width: 2; marker-end: url(#arrowhead); }
+      .edge-label { font-family: sans-serif; font-size: 13px; fill: #333; text-anchor: middle; dominant-baseline: middle; }
+      .edge-label-bg { fill: white; fill-opacity: 0.9; }
+    </style>
+  </defs>
+  
+  <!-- Vertices: s(80,100), A(210,50), B(210,150), t(380,100) -->
+  <!-- Edges -->
+  <!-- s->A -->
+  <path class="edge" d="M 110 90 Q 145 70 180 60"/>
+  <text class="edge-label" x="145" y="55">0/3</text>
+  <!-- s->B -->
+  <path class="edge" d="M 110 110 Q 145 130 180 140"/>
+  <text class="edge-label" x="145" y="148">0/2</text>
+  <!-- A->B -->
+  <path class="edge" d="M 210 80 L 210 120"/>
+  <text class="edge-label" x="225" y="100">0/1</text>
+  <!-- A->t -->
+  <path class="edge" d="M 240 60 Q 295 70 350 90"/>
+  <text class="edge-label" x="295" y="63">0/2</text>
+  <!-- B->t -->
+  <path class="edge" d="M 240 140 Q 295 130 350 110"/>
+  <text class="edge-label" x="295" y="138">0/3</text>
+  
+  <!-- Vertices -->
+  <circle class="vertex" cx="80" cy="100" r="25"/>
+  <text class="vertex-label" x="80" y="100">s</text>
+  
+  <circle class="vertex" cx="210" cy="50" r="25"/>
+  <text class="vertex-label" x="210" y="50">A</text>
+  
+  <circle class="vertex" cx="210" cy="150" r="25"/>
+  <text class="vertex-label" x="210" y="150">B</text>
+  
+  <circle class="vertex" cx="380" cy="100" r="25"/>
+  <text class="vertex-label" x="380" y="100">t</text>
+</svg>

--- a/src/graph/dinic_phase1_blocking.svg
+++ b/src/graph/dinic_phase1_blocking.svg
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="500" height="200" viewBox="0 0 500 200" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <marker id="arrowhead" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto">
+      <polygon points="0 0, 10 3.5, 0 7" fill="#333"/>
+    </marker>
+    <marker id="arrowhead-blue" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto">
+      <polygon points="0 0, 10 3.5, 0 7" fill="#2196F3"/>
+    </marker>
+    <style>
+      .vertex { fill: #e0e0e0; stroke: #333; stroke-width: 2; }
+      .vertex-label { font-family: sans-serif; font-size: 16px; font-weight: bold; fill: #333; text-anchor: middle; dominant-baseline: middle; }
+      .edge { fill: none; stroke: #333; stroke-width: 2; marker-end: url(#arrowhead); }
+      .edge-saturated { fill: none; stroke: #333; stroke-width: 2; stroke-dasharray: 6,4; marker-end: url(#arrowhead); }
+      .edge-flow { fill: none; stroke: #2196F3; stroke-width: 3; marker-end: url(#arrowhead-blue); }
+      .edge-label { font-family: sans-serif; font-size: 13px; fill: #333; text-anchor: middle; dominant-baseline: middle; }
+      .edge-label-flow { font-family: sans-serif; font-size: 13px; fill: #2196F3; font-weight: bold; text-anchor: middle; dominant-baseline: middle; }
+      .edge-label-sat { font-family: sans-serif; font-size: 13px; fill: #333; text-anchor: middle; dominant-baseline: middle; }
+    </style>
+  </defs>
+  
+  <!-- s->A: 2/3 (flow shown in blue) -->
+  <path class="edge" d="M 110 90 Q 145 70 180 60"/>
+  <path class="edge-flow" d="M 110 90 Q 145 70 180 60" stroke-dasharray="none"/>
+  <text class="edge-label-flow" x="145" y="55">2/3</text>
+  
+  <!-- s->B: 2/2 (saturated) -->
+  <path class="edge-saturated" d="M 110 110 Q 145 130 180 140"/>
+  <text class="edge-label-sat" x="145" y="148">2/2</text>
+  
+  <!-- A->B: 0/1 -->
+  <path class="edge" d="M 210 80 L 210 120"/>
+  <text class="edge-label" x="225" y="100">0/1</text>
+  
+  <!-- A->t: 2/2 (saturated) -->
+  <path class="edge-saturated" d="M 240 60 Q 295 70 350 90"/>
+  <text class="edge-label-sat" x="295" y="63">2/2</text>
+  
+  <!-- B->t: 2/3 (flow shown in blue) -->
+  <path class="edge" d="M 240 140 Q 295 130 350 110"/>
+  <path class="edge-flow" d="M 240 140 Q 295 130 350 110" stroke-dasharray="none"/>
+  <text class="edge-label-flow" x="295" y="138">2/3</text>
+  
+  <!-- Vertices -->
+  <circle class="vertex" cx="80" cy="100" r="25"/>
+  <text class="vertex-label" x="80" y="100">s</text>
+  
+  <circle class="vertex" cx="210" cy="50" r="25"/>
+  <text class="vertex-label" x="210" y="50">A</text>
+  
+  <circle class="vertex" cx="210" cy="150" r="25"/>
+  <text class="vertex-label" x="210" y="150">B</text>
+  
+  <circle class="vertex" cx="380" cy="100" r="25"/>
+  <text class="vertex-label" x="380" y="100">t</text>
+</svg>

--- a/src/graph/dinic_phase1_blocking.svg
+++ b/src/graph/dinic_phase1_blocking.svg
@@ -4,41 +4,36 @@
     <marker id="arrowhead" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto">
       <polygon points="0 0, 10 3.5, 0 7" fill="#333"/>
     </marker>
-    <marker id="arrowhead-blue" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto">
-      <polygon points="0 0, 10 3.5, 0 7" fill="#2196F3"/>
-    </marker>
     <style>
       .vertex { fill: #e0e0e0; stroke: #333; stroke-width: 2; }
       .vertex-label { font-family: sans-serif; font-size: 16px; font-weight: bold; fill: #333; text-anchor: middle; dominant-baseline: middle; }
       .edge { fill: none; stroke: #333; stroke-width: 2; marker-end: url(#arrowhead); }
       .edge-saturated { fill: none; stroke: #333; stroke-width: 2; stroke-dasharray: 6,4; marker-end: url(#arrowhead); }
-      .edge-flow { fill: none; stroke: #2196F3; stroke-width: 3; marker-end: url(#arrowhead-blue); }
+      .edge-flow { fill: none; stroke: #2196F3; stroke-width: 3; marker-end: url(#arrowhead); }
       .edge-label { font-family: sans-serif; font-size: 13px; fill: #333; text-anchor: middle; dominant-baseline: middle; }
       .edge-label-flow { font-family: sans-serif; font-size: 13px; fill: #2196F3; font-weight: bold; text-anchor: middle; dominant-baseline: middle; }
-      .edge-label-sat { font-family: sans-serif; font-size: 13px; fill: #333; text-anchor: middle; dominant-baseline: middle; }
+      .edge-label-sat { font-family: sans-serif; font-size: 13px; fill: #333; font-weight: bold; text-anchor: middle; dominant-baseline: middle; }
     </style>
   </defs>
   
-  <!-- s->A: 2/3 (flow shown in blue) -->
-  <path class="edge" d="M 110 90 Q 145 70 180 60"/>
-  <path class="edge-flow" d="M 110 90 Q 145 70 180 60" stroke-dasharray="none"/>
+  <!-- s->A: 2/3 (flow path, blue) -->
+  <path class="edge-flow" d="M 110 90 Q 145 70 180 60"/>
   <text class="edge-label-flow" x="145" y="55">2/3</text>
   
-  <!-- s->B: 2/2 (saturated) -->
+  <!-- s->B: 2/2 (saturated, dashed) -->
   <path class="edge-saturated" d="M 110 110 Q 145 130 180 140"/>
   <text class="edge-label-sat" x="145" y="148">2/2</text>
   
-  <!-- A->B: 0/1 -->
+  <!-- A->B: 0/1 (unchanged) -->
   <path class="edge" d="M 210 80 L 210 120"/>
   <text class="edge-label" x="225" y="100">0/1</text>
   
-  <!-- A->t: 2/2 (saturated) -->
+  <!-- A->t: 2/2 (saturated, dashed) -->
   <path class="edge-saturated" d="M 240 60 Q 295 70 350 90"/>
   <text class="edge-label-sat" x="295" y="63">2/2</text>
   
-  <!-- B->t: 2/3 (flow shown in blue) -->
-  <path class="edge" d="M 240 140 Q 295 130 350 110"/>
-  <path class="edge-flow" d="M 240 140 Q 295 130 350 110" stroke-dasharray="none"/>
+  <!-- B->t: 2/3 (flow path, blue) -->
+  <path class="edge-flow" d="M 240 140 Q 295 130 350 110"/>
   <text class="edge-label-flow" x="295" y="138">2/3</text>
   
   <!-- Vertices -->

--- a/src/graph/dinic_phase1_levels.svg
+++ b/src/graph/dinic_phase1_levels.svg
@@ -11,27 +11,19 @@
       .vertex { fill: #e0e0e0; stroke: #333; stroke-width: 2; }
       .vertex-label { font-family: sans-serif; font-size: 16px; font-weight: bold; fill: #333; text-anchor: middle; dominant-baseline: middle; }
       .level-label { font-family: sans-serif; font-size: 13px; fill: #2196F3; font-weight: bold; text-anchor: middle; dominant-baseline: middle; }
-      .edge { fill: none; stroke: #333; stroke-width: 1.5; marker-end: url(#arrowhead); opacity: 0.4; }
+      .edge-residual { fill: none; stroke: #999; stroke-width: 1.5; marker-end: url(#arrowhead); stroke-dasharray: 4,4; }
       .edge-level { fill: none; stroke: #2196F3; stroke-width: 2.5; marker-end: url(#arrowhead-blue); }
-      .edge-label { font-family: sans-serif; font-size: 12px; fill: #333; text-anchor: middle; dominant-baseline: middle; }
+      .edge-label-residual { font-family: sans-serif; font-size: 12px; fill: #999; text-anchor: middle; dominant-baseline: middle; }
       .edge-label-level { font-family: sans-serif; font-size: 12px; fill: #2196F3; font-weight: bold; text-anchor: middle; dominant-baseline: middle; }
-      .edge-label-bg { fill: white; fill-opacity: 0.9; }
     </style>
   </defs>
   
-  <!-- All edges (faded) -->
-  <path class="edge" d="M 110 90 Q 145 70 180 60"/>
-  <text class="edge-label" x="145" y="55">0/3</text>
-  <path class="edge" d="M 110 110 Q 145 130 180 140"/>
-  <text class="edge-label" x="145" y="148">0/2</text>
-  <path class="edge" d="M 210 80 L 210 120"/>
-  <text class="edge-label" x="225" y="100">0/1</text>
-  <path class="edge" d="M 240 60 Q 295 70 350 90"/>
-  <text class="edge-label" x="295" y="63">0/2</text>
-  <path class="edge" d="M 240 140 Q 295 130 350 110"/>
-  <text class="edge-label" x="295" y="138">0/3</text>
+  <!-- Residual edges NOT in level graph (dashed gray) -->
+  <!-- A->B: not in level graph -->
+  <path class="edge-residual" d="M 210 80 L 210 120"/>
+  <text class="edge-label-residual" x="225" y="100">0/1</text>
   
-  <!-- Level graph edges (highlighted) -->
+  <!-- Level graph edges (solid blue) -->
   <!-- s->A -->
   <path class="edge-level" d="M 110 90 Q 145 70 180 60"/>
   <text class="edge-label-level" x="145" y="55">0/3</text>

--- a/src/graph/dinic_phase1_levels.svg
+++ b/src/graph/dinic_phase1_levels.svg
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="500" height="220" viewBox="0 0 500 220" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <marker id="arrowhead" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto">
+      <polygon points="0 0, 10 3.5, 0 7" fill="#333"/>
+    </marker>
+    <marker id="arrowhead-blue" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto">
+      <polygon points="0 0, 10 3.5, 0 7" fill="#2196F3"/>
+    </marker>
+    <style>
+      .vertex { fill: #e0e0e0; stroke: #333; stroke-width: 2; }
+      .vertex-label { font-family: sans-serif; font-size: 16px; font-weight: bold; fill: #333; text-anchor: middle; dominant-baseline: middle; }
+      .level-label { font-family: sans-serif; font-size: 13px; fill: #2196F3; font-weight: bold; text-anchor: middle; dominant-baseline: middle; }
+      .edge { fill: none; stroke: #333; stroke-width: 1.5; marker-end: url(#arrowhead); opacity: 0.4; }
+      .edge-level { fill: none; stroke: #2196F3; stroke-width: 2.5; marker-end: url(#arrowhead-blue); }
+      .edge-label { font-family: sans-serif; font-size: 12px; fill: #333; text-anchor: middle; dominant-baseline: middle; }
+      .edge-label-level { font-family: sans-serif; font-size: 12px; fill: #2196F3; font-weight: bold; text-anchor: middle; dominant-baseline: middle; }
+      .edge-label-bg { fill: white; fill-opacity: 0.9; }
+    </style>
+  </defs>
+  
+  <!-- All edges (faded) -->
+  <path class="edge" d="M 110 90 Q 145 70 180 60"/>
+  <text class="edge-label" x="145" y="55">0/3</text>
+  <path class="edge" d="M 110 110 Q 145 130 180 140"/>
+  <text class="edge-label" x="145" y="148">0/2</text>
+  <path class="edge" d="M 210 80 L 210 120"/>
+  <text class="edge-label" x="225" y="100">0/1</text>
+  <path class="edge" d="M 240 60 Q 295 70 350 90"/>
+  <text class="edge-label" x="295" y="63">0/2</text>
+  <path class="edge" d="M 240 140 Q 295 130 350 110"/>
+  <text class="edge-label" x="295" y="138">0/3</text>
+  
+  <!-- Level graph edges (highlighted) -->
+  <!-- s->A -->
+  <path class="edge-level" d="M 110 90 Q 145 70 180 60"/>
+  <text class="edge-label-level" x="145" y="55">0/3</text>
+  <!-- s->B -->
+  <path class="edge-level" d="M 110 110 Q 145 130 180 140"/>
+  <text class="edge-label-level" x="145" y="148">0/2</text>
+  <!-- A->t -->
+  <path class="edge-level" d="M 240 60 Q 295 70 350 90"/>
+  <text class="edge-label-level" x="295" y="63">0/2</text>
+  <!-- B->t -->
+  <path class="edge-level" d="M 240 140 Q 295 130 350 110"/>
+  <text class="edge-label-level" x="295" y="138">0/3</text>
+  
+  <!-- Vertices with level labels -->
+  <circle class="vertex" cx="80" cy="100" r="25"/>
+  <text class="vertex-label" x="80" y="100">s</text>
+  <text class="level-label" x="80" y="140">level 0</text>
+  
+  <circle class="vertex" cx="210" cy="50" r="25"/>
+  <text class="vertex-label" x="210" y="50">A</text>
+  <text class="level-label" x="210" y="90">level 1</text>
+  
+  <circle class="vertex" cx="210" cy="150" r="25"/>
+  <text class="vertex-label" x="210" y="150">B</text>
+  <text class="level-label" x="210" y="190">level 1</text>
+  
+  <circle class="vertex" cx="380" cy="100" r="25"/>
+  <text class="vertex-label" x="380" y="100">t</text>
+  <text class="level-label" x="380" y="140">level 2</text>
+</svg>

--- a/src/graph/dinic_phase2_final.svg
+++ b/src/graph/dinic_phase2_final.svg
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="500" height="220" viewBox="0 0 500 220" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <marker id="arrowhead" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto">
+      <polygon points="0 0, 10 3.5, 0 7" fill="#333"/>
+    </marker>
+    <marker id="arrowhead-blue" markerWidth="10" markerHeight="7" refX="9" refY="3.5" orient="auto">
+      <polygon points="0 0, 10 3.5, 0 7" fill="#2196F3"/>
+    </marker>
+    <style>
+      .vertex { fill: #e0e0e0; stroke: #333; stroke-width: 2; }
+      .vertex-label { font-family: sans-serif; font-size: 16px; font-weight: bold; fill: #333; text-anchor: middle; dominant-baseline: middle; }
+      .level-label { font-family: sans-serif; font-size: 13px; fill: #2196F3; font-weight: bold; text-anchor: middle; dominant-baseline: middle; }
+      .edge { fill: none; stroke: #333; stroke-width: 1.5; marker-end: url(#arrowhead); opacity: 0.4; }
+      .edge-saturated { fill: none; stroke: #333; stroke-width: 1.5; stroke-dasharray: 6,4; marker-end: url(#arrowhead); opacity: 0.4; }
+      .edge-level { fill: none; stroke: #2196F3; stroke-width: 2.5; marker-end: url(#arrowhead-blue); }
+      .edge-flow { fill: none; stroke: #2196F3; stroke-width: 3; marker-end: url(#arrowhead-blue); }
+      .edge-label { font-family: sans-serif; font-size: 12px; fill: #333; text-anchor: middle; dominant-baseline: middle; opacity: 0.6; }
+      .edge-label-sat { font-family: sans-serif; font-size: 12px; fill: #333; text-anchor: middle; dominant-baseline: middle; opacity: 0.6; }
+      .edge-label-flow { font-family: sans-serif; font-size: 12px; fill: #2196F3; font-weight: bold; text-anchor: middle; dominant-baseline: middle; }
+      .edge-label-level { font-family: sans-serif; font-size: 12px; fill: #2196F3; font-weight: bold; text-anchor: middle; dominant-baseline: middle; }
+    </style>
+  </defs>
+  
+  <!-- All edges (faded) -->
+  <!-- s->A: 3/3 saturated -->
+  <path class="edge-saturated" d="M 110 90 Q 145 70 180 60"/>
+  <text class="edge-label-sat" x="145" y="55">3/3</text>
+  
+  <!-- s->B: 2/2 saturated -->
+  <path class="edge-saturated" d="M 110 110 Q 145 130 180 140"/>
+  <text class="edge-label-sat" x="145" y="148">2/2</text>
+  
+  <!-- A->B: 1/1 (now in level graph, saturated) -->
+  <path class="edge-level" d="M 210 80 L 210 120"/>
+  <text class="edge-label-level" x="225" y="100">1/1</text>
+  
+  <!-- A->t: 2/2 saturated -->
+  <path class="edge-saturated" d="M 240 60 Q 295 70 350 90"/>
+  <text class="edge-label-sat" x="295" y="63">2/2</text>
+  
+  <!-- B->t: 3/3 saturated -->
+  <path class="edge-saturated" d="M 240 140 Q 295 130 350 110"/>
+  <text class="edge-label-sat" x="295" y="138">3/3</text>
+  
+  <!-- Highlight the augmenting path s->A->B->t in phase 2 -->
+  <!-- s->A residual was 1, now saturated -->
+  <path class="edge-flow" d="M 110 90 Q 145 70 180 60" stroke-dasharray="none" opacity="0.5"/>
+  <!-- A->B was 0/1, now 1/1 -->
+  <path class="edge-flow" d="M 210 80 L 210 120" stroke-dasharray="none" opacity="0.5"/>
+  <!-- B->t residual was 1, now saturated -->
+  <path class="edge-flow" d="M 240 140 Q 295 130 350 110" stroke-dasharray="none" opacity="0.5"/>
+  
+  <!-- Vertices with level labels -->
+  <circle class="vertex" cx="80" cy="100" r="25"/>
+  <text class="vertex-label" x="80" y="100">s</text>
+  <text class="level-label" x="80" y="140">level 0</text>
+  
+  <circle class="vertex" cx="210" cy="50" r="25"/>
+  <text class="vertex-label" x="210" y="50">A</text>
+  <text class="level-label" x="210" y="90">level 1</text>
+  
+  <circle class="vertex" cx="210" cy="150" r="25"/>
+  <text class="vertex-label" x="210" y="150">B</text>
+  <text class="level-label" x="210" y="190">level 2</text>
+  
+  <circle class="vertex" cx="380" cy="100" r="25"/>
+  <text class="vertex-label" x="380" y="100">t</text>
+  <text class="level-label" x="380" y="140">level 3</text>
+</svg>

--- a/src/graph/dinic_phase2_final.svg
+++ b/src/graph/dinic_phase2_final.svg
@@ -11,18 +11,14 @@
       .vertex { fill: #e0e0e0; stroke: #333; stroke-width: 2; }
       .vertex-label { font-family: sans-serif; font-size: 16px; font-weight: bold; fill: #333; text-anchor: middle; dominant-baseline: middle; }
       .level-label { font-family: sans-serif; font-size: 13px; fill: #2196F3; font-weight: bold; text-anchor: middle; dominant-baseline: middle; }
-      .edge { fill: none; stroke: #333; stroke-width: 1.5; marker-end: url(#arrowhead); opacity: 0.4; }
-      .edge-saturated { fill: none; stroke: #333; stroke-width: 1.5; stroke-dasharray: 6,4; marker-end: url(#arrowhead); opacity: 0.4; }
+      .edge-saturated { fill: none; stroke: #999; stroke-width: 1.5; stroke-dasharray: 6,4; marker-end: url(#arrowhead); }
       .edge-level { fill: none; stroke: #2196F3; stroke-width: 2.5; marker-end: url(#arrowhead-blue); }
-      .edge-flow { fill: none; stroke: #2196F3; stroke-width: 3; marker-end: url(#arrowhead-blue); }
-      .edge-label { font-family: sans-serif; font-size: 12px; fill: #333; text-anchor: middle; dominant-baseline: middle; opacity: 0.6; }
-      .edge-label-sat { font-family: sans-serif; font-size: 12px; fill: #333; text-anchor: middle; dominant-baseline: middle; opacity: 0.6; }
-      .edge-label-flow { font-family: sans-serif; font-size: 12px; fill: #2196F3; font-weight: bold; text-anchor: middle; dominant-baseline: middle; }
+      .edge-label-sat { font-family: sans-serif; font-size: 12px; fill: #999; text-anchor: middle; dominant-baseline: middle; }
       .edge-label-level { font-family: sans-serif; font-size: 12px; fill: #2196F3; font-weight: bold; text-anchor: middle; dominant-baseline: middle; }
     </style>
   </defs>
   
-  <!-- All edges (faded) -->
+  <!-- Saturated edges (dashed gray) -->
   <!-- s->A: 3/3 saturated -->
   <path class="edge-saturated" d="M 110 90 Q 145 70 180 60"/>
   <text class="edge-label-sat" x="145" y="55">3/3</text>
@@ -30,10 +26,6 @@
   <!-- s->B: 2/2 saturated -->
   <path class="edge-saturated" d="M 110 110 Q 145 130 180 140"/>
   <text class="edge-label-sat" x="145" y="148">2/2</text>
-  
-  <!-- A->B: 1/1 (now in level graph, saturated) -->
-  <path class="edge-level" d="M 210 80 L 210 120"/>
-  <text class="edge-label-level" x="225" y="100">1/1</text>
   
   <!-- A->t: 2/2 saturated -->
   <path class="edge-saturated" d="M 240 60 Q 295 70 350 90"/>
@@ -43,13 +35,9 @@
   <path class="edge-saturated" d="M 240 140 Q 295 130 350 110"/>
   <text class="edge-label-sat" x="295" y="138">3/3</text>
   
-  <!-- Highlight the augmenting path s->A->B->t in phase 2 -->
-  <!-- s->A residual was 1, now saturated -->
-  <path class="edge-flow" d="M 110 90 Q 145 70 180 60" stroke-dasharray="none" opacity="0.5"/>
-  <!-- A->B was 0/1, now 1/1 -->
-  <path class="edge-flow" d="M 210 80 L 210 120" stroke-dasharray="none" opacity="0.5"/>
-  <!-- B->t residual was 1, now saturated -->
-  <path class="edge-flow" d="M 240 140 Q 295 130 350 110" stroke-dasharray="none" opacity="0.5"/>
+  <!-- Phase 2 level graph edge (solid blue) - A->B now in level graph -->
+  <path class="edge-level" d="M 210 80 L 210 120"/>
+  <text class="edge-label-level" x="225" y="100">1/1</text>
   
   <!-- Vertices with level labels -->
   <circle class="vertex" cx="80" cy="100" r="25"/>


### PR DESCRIPTION
## Summary

Fixes #1637.

Adds a step-by-step worked example to the Dinic's algorithm article to make
the algorithm easier to understand in practice.

The example uses a small flow network and walks through the complete
execution of Dinic's algorithm:

- construction of the initial residual network
- BFS and the resulting level graph
- DFS augmentations
- construction of a blocking flow
- residual-capacity updates
- a second BFS phase
- the second blocking-flow augmentation
- termination and the final maximum-flow value

## Why

The current article explains the definitions, correctness, complexity, and
implementation of Dinic's algorithm, but does not provide a concrete
walkthrough showing how the different phases interact.

This example is intended to bridge that gap while keeping the explanation
small enough to follow by hand.

## Example

The walkthrough uses the following network:

- s → A with capacity 3
- s → B with capacity 2
- A → B with capacity 1
- A → t with capacity 2
- B → t with capacity 3

The execution demonstrates two Dinic phases and results in a maximum flow
of 5.

Each flow value, residual capacity, level assignment, and phase transition
has been independently checked against the graph.

## Visuals

The example includes clean SVG diagrams showing the graph state at the
important stages of the algorithm.

The diagrams contain only graph information such as vertices, directed
edges, capacities/flows, and level values. The explanatory text remains
outside the diagrams so that the walkthrough remains readable and
accessible.

## Scope

This change is documentation-only and does not modify the existing Dinic
implementation, correctness proof, complexity analysis, or unrelated
articles.

## Validation

- Documentation formatting/checks were run.
- The documentation build was run where supported by the repository.
- The complete flow calculation and residual-network transitions were
  independently verified.
- The final diff was reviewed to ensure that only the intended article and
  diagram assets were changed.

Closes #1637.